### PR TITLE
feat: import fplreview projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Genetic algorithm for building English Premier League Fantasy Football teams.
 
-The project imports Fantasy Premier League player and fixture data, estimates player scores across upcoming gameweeks, and searches for a high-scoring valid squad.
+The project imports fplreview.com player projection exports and searches for a high-scoring valid squad.
 
 ## Quick start
 
@@ -12,15 +12,15 @@ python3 code/GA.py
 
 ## Data files
 
-Runtime data is intentionally kept out of Git. Put these files in `data/`:
+Runtime data is intentionally kept out of Git. Export projections from fplreview.com and save the CSV as:
 
-- `playerdata`: JSON player data in the format produced by `fplscraper`
-- `fixturedata`: one JSON fixture record per line
-- `playerlast10.csv`: recent player home/away scoring data
+```text
+data/fplreview.csv
+```
 
-The loader also checks the current working directory and `code/` for backwards compatibility with the original layout.
+FPLgen uses the configured gameweek columns from the export as the expected score for each player. Those values are loaded directly; FPLgen does not apply additional projection adjustments for strength of schedule, home/away splits, availability, or expected minutes.
 
-The run writes `data/playerkeydata`, a generated inspection file with player scoring inputs and projections.
+The run writes `data/playerkeydata`, a generated inspection file showing the imported scoring values used by the optimizer.
 
 ## Development
 
@@ -30,12 +30,6 @@ Run the syntax and smoke checks with:
 python3 -m py_compile code/*.py
 python3 -m unittest discover -s tests
 ```
-
-## Related project
-
-Input data can be produced by:
-
-https://github.com/markbarrington/fplscraper
 
 ## Credits
 

--- a/code/fpl.py
+++ b/code/fpl.py
@@ -350,65 +350,156 @@ class fpl():
 
     bank = 0.0
 
-    # Read the playerdata into the player global variable.
-    # Output a playerkeydata file
-    # Generate the four week lookahead score for each player
     @staticmethod
-    def getplayerdata():
-        global players, fixtures
+    def fplreview_gameweek_columns(fieldnames):
+        columns = {}
+        missing = []
+        for week in range(gameweek, gameweek + forecastweeks):
+            candidates = [
+                "%s_Pts" % week,
+                "GW%s_Pts" % week,
+                "GW%s Pts" % week,
+                "%s_PTS" % week,
+                "GW%s_PTS" % week,
+            ]
+            found = None
+            for candidate in candidates:
+                if candidate in fieldnames:
+                    found = candidate
+                    break
+            if found is None:
+                missing.append("%s_Pts" % week)
+            else:
+                columns[week - gameweek + 1] = found
 
+        if missing:
+            raise ValueError(
+                "Missing required fplreview gameweek columns: %s" % ", ".join(missing)
+            )
+
+        return columns
+
+    @staticmethod
+    def fplreview_price(value):
+        price = float(value)
+        if price <= 20:
+            price *= 10
+        return int(round(price))
+
+    @staticmethod
+    def fplreview_position(value):
+        position = str(value).strip().lower()
+        positions = {
+            "1": 1,
+            "gk": 1,
+            "gkp": 1,
+            "goalkeeper": 1,
+            "2": 2,
+            "def": 2,
+            "defender": 2,
+            "3": 3,
+            "mid": 3,
+            "midfielder": 3,
+            "4": 4,
+            "fwd": 4,
+            "for": 4,
+            "forward": 4,
+        }
+        if position not in positions:
+            raise ValueError("Unknown fplreview position: %s" % value)
+        return positions[position]
+
+    @staticmethod
+    def fplreview_team(value):
+        global teamid
+
+        team_name = str(value).strip()
+        for existing_id, existing_name in teamid.items():
+            if existing_name.lower() == team_name.lower():
+                return int(existing_id), existing_name
+
+        next_id = max(int(existing_id) for existing_id in teamid.keys()) + 1
+        teamid[str(next_id)] = team_name
+        return next_id, team_name
+
+    @staticmethod
+    def map_fplreview_rows(rows, fieldnames):
+        required = ["Pos", "ID", "Name", "BV", "SV", "Team"]
+        missing = [field for field in required if field not in fieldnames]
+        if missing:
+            raise ValueError("Missing required fplreview columns: %s" % ", ".join(missing))
+
+        point_columns = fpl.fplreview_gameweek_columns(fieldnames)
         players = []
-        fixtures = []
+        for row in rows:
+            players.append(fpl.map_fplreview_player(row, point_columns))
+        return players
 
-        with open(data_file('playerdata'), 'r', encoding='utf-8') as p:
-            players = json.load(p)
+    @staticmethod
+    def map_fplreview_player(row, point_columns):
+        player_id = int(row["ID"])
+        element_type = fpl.fplreview_position(row["Pos"])
+        team, team_name = fpl.fplreview_team(row["Team"])
+        now_cost = fpl.fplreview_price(row["BV"])
+        sellprice = fpl.fplreview_price(row["SV"])
 
-        with open(data_file("playerlast10.csv"), "r", encoding='utf-8-sig', newline='') as pl:
-            playerslast10 = list(csv.reader(pl))
+        player = {
+            "id": player_id,
+            "code": player_id,
+            "second_name": row["Name"],
+            "web_name": row["Name"],
+            "team": team,
+            "team_name": team_name,
+            "element_type": element_type,
+            "type_name": playertypes[element_type - 1],
+            "now_cost": now_cost,
+            "sellprice": sellprice,
+            "status": "a",
+            "picked": False,
+            "minutes": 0,
+            "total_points": 0,
+            "tsp": 0,
+            "home": 0,
+            "away": 0,
+            "homegames": 0,
+            "awaygames": 0,
+            "otherteams": ["NONE"] * forecastweeks,
+        }
 
-        for player in players:
-            found = False
-            for playerlast in playerslast10:
-                if len(playerlast) > 10 and playerlast[1] == str(player['code']):
-                    player['home'] = float(playerlast[7])
-                    player['homegames'] = int(playerlast[8])
-                    player['away'] = float(playerlast[9])
-                    player['awaygames'] = int(playerlast[10])
-                    found = True
-            if found == False:
-                player['home'] = 0
-                player['away'] = 0
-                player['homegames'] = 0
-                player['awaygames'] = 0
+        lookahead = 0
+        for week, column in point_columns.items():
+            points = float(row[column])
+            player[str(week)] = points
+            lookahead += points
 
-        with open(data_file('fixturedata'), 'r', encoding='utf-8') as f:
-            for line in f:
-                fixtures.append(json.loads(line))
+        player["thisweekpoints"] = player["1"]
+        player["lookaheadpoints"] = lookahead
+        player["ppg"] = lookahead / float(forecastweeks)
+        player["total_points"] = lookahead
+        player["tsp"] = lookahead
 
+        return player
+
+    @staticmethod
+    def load_fplreview_players(filename):
+        with open(filename, "r", encoding="utf-8-sig", newline="") as csvfile:
+            reader = csv.DictReader(csvfile)
+            if reader.fieldnames is None:
+                raise ValueError("fplreview CSV has no header row")
+            rows = list(reader)
+            return fpl.map_fplreview_rows(rows, reader.fieldnames)
+
+    @staticmethod
+    def write_playerkeydata(loaded_players):
         output = open(data_file('playerkeydata', for_write=True), 'w', encoding='utf-8-sig')
 
-        for player in players:
-
-            player['picked'] = False
-            player['sellprice'] = player['now_cost']
-            player['team_name'] = teamid[str(player['team'])]
-
-            # Generate the four week lookahead score for the player
-            fpl.lookaheadpoints(player, gameweek)
-
-            # Zero out the scores for unavailable players
-
-            if player['status'] != 'a':
-                for week in range(gameweek, gameweek+forecastweeks):
-                    player[str(week-gameweek+1)] = 0
-
-            # Output key data for inspection to a file
+        for player in loaded_players:
             playerdata = player['second_name']
             playerdata += "," + str(player['total_points'])
             playerdata += "," + str(player['minutes'])
             playerdata += "," + str(player['tsp'])
             playerdata += "," + str(player['now_cost'])
-            playerdata += "," + teamid[str(player['team'])]
+            playerdata += "," + player['team_name']
             playerdata += "," + playertype[str(player['element_type'])]
             playerdata += "," + str(player['lookaheadpoints'])
             playerdata += "," + str(player['thisweekpoints'])
@@ -418,6 +509,18 @@ class fpl():
             output.write(playerdata + '\n')
 
         output.close()
+
+    # Read the fplreview export into the player global variable.
+    # Output a playerkeydata inspection file.
+    @staticmethod
+    def getplayerdata():
+        global players, fixtures
+
+        fixtures = []
+        imported_players = fpl.load_fplreview_players(data_file('fplreview.csv'))
+
+        players = imported_players
+        fpl.write_playerkeydata(players)
 
     # Generate a four week lookahead score for a player
     @staticmethod

--- a/docs/brainstorms/2026-06-02-fplreview-import-requirements.md
+++ b/docs/brainstorms/2026-06-02-fplreview-import-requirements.md
@@ -1,0 +1,122 @@
+---
+date: 2026-06-02
+topic: fplreview-import
+---
+
+# Requirements: fplreview CSV Import
+
+## Summary
+
+FPLgen will replace its old three-file runtime data input with a single fplreview.com CSV export at `data/fplreview.csv`. The importer will map that CSV into the existing internal player shape so the current optimizer can keep running with minimal downstream logic changes, using fplreview gameweek points as the final expected score for each configured gameweek.
+
+---
+
+## Problem Frame
+
+The current repo was written against an older Fantasy Premier League data shape. It expects `playerdata`, `fixturedata`, and `playerlast10.csv`, then applies local projection logic before scoring teams. The FPL APIs and surrounding tooling have changed since then, and the more useful source of truth is now a single fplreview.com export file.
+
+This change should modernize the input path without turning into an optimizer rewrite. fplreview projections already include availability and expected-minutes effects, so FPLgen should import those values directly and avoid re-adjusting them.
+
+---
+
+## Key Decisions
+
+- **Use fplreview CSV as the only runtime input.** The old three-file data path should no longer be the normal supported runtime flow.
+- **Keep the app logic mostly intact.** The import layer adapts fplreview data into the current internal representation instead of forcing the GA, scoring, and transfer code to learn a new data shape.
+- **Treat fplreview points as final expected values.** Gameweek points from the CSV are the player scores for those gameweeks, with no strength-of-schedule, home/away, availability, or xMins adjustment added by FPLgen.
+- **Keep hard-coded gameweek settings for now.** The importer validates against the current configured `gameweek` and `forecastweeks` values rather than introducing CLI configuration in this change.
+- **Keep `playerkeydata` for inspection.** It remains as a generated artifact, but its role becomes showing loaded projection values rather than explaining FPLgen-adjusted projections.
+
+---
+
+## Requirements
+
+**Input and validation**
+
+- R1. FPLgen reads runtime projection data from `data/fplreview.csv`.
+- R2. The fplreview CSV must include full optimizer-ready player fields: player ID, player name, team, position, buying value, selling value, and gameweek points for each configured forecast week.
+- R3. The importer fails fast with a clear error when a required player field is missing.
+- R4. The importer fails fast with a clear error when the CSV does not include the gameweek point columns required by the current hard-coded `gameweek` and `forecastweeks` settings.
+- R5. The importer treats all fplreview-imported players as internally available because fplreview expected points already account for availability and expected minutes.
+
+**Field mapping**
+
+- R6. The importer maps fplreview player fields into the existing internal player shape used by current squad generation, validation, scoring, transfer, and output code.
+- R7. The importer maps fplreview position values into the existing internal position representation.
+- R8. The importer maps fplreview team values into the existing internal team and team-name representation.
+- R9. For new squad generation, player cost comes from fplreview buying value.
+- R10. For transfers, imported data must preserve both selling value for outgoing-player affordability and buying value for incoming-player affordability, without changing the existing transfer logic in this feature.
+- R11. Imported gameweek point values become the existing per-week player score fields used by scoring.
+
+**Runtime behavior**
+
+- R12. Existing scoring, squad generation, transfer, budget, chip, and team-validity behavior should remain unchanged except where a small compatibility change is unavoidable to consume the mapped fplreview fields.
+- R13. FPLgen should not call live FPL APIs as part of this feature.
+- R14. FPLgen should not apply the old projection calculation path to fplreview-imported gameweek points.
+- R15. `playerkeydata` should still be written after import and should reflect the imported fplreview projection values.
+
+**Tests and documentation**
+
+- R16. The repo includes a committed synthetic fplreview-format CSV fixture for import and field-mapping tests.
+- R17. The synthetic fixture proves import and mapping behavior only; it does not need enough players to support an end-to-end GA run.
+- R18. README documentation is updated so the normal quick-start data path tells users to put the fplreview export at `data/fplreview.csv`.
+- R19. README documentation no longer presents `playerdata`, `fixturedata`, and `playerlast10.csv` as the normal runtime input flow.
+
+---
+
+## Key Flow
+
+- F1. Import fplreview projections
+  - **Trigger:** The user runs FPLgen with `data/fplreview.csv` present.
+  - **Steps:** FPLgen reads the CSV, validates required fields and configured gameweek columns, maps fplreview values into the existing internal player representation, and makes the mapped players available to the current optimizer.
+  - **Outcome:** The current GA/scoring pipeline runs against fplreview expected points without applying old projection adjustments.
+  - **Covered by:** R1-R15
+
+```mermaid
+flowchart TB
+  A["data/fplreview.csv"] --> B["Validate required fields"]
+  B --> C["Map to existing player shape"]
+  C --> D["Current squad generation and scoring"]
+  C --> E["playerkeydata inspection output"]
+```
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R2, R3.** Given `data/fplreview.csv` is missing the player position field, when FPLgen imports data, then import stops with a clear missing-field error.
+- AE2. **Covers R4.** Given the configured horizon requires six gameweek point columns and the CSV omits one, when FPLgen imports data, then import stops before running the optimizer.
+- AE3. **Covers R9, R10.** Given a player row includes both buying value and selling value, when that player is mapped, then the internal player has the buying value available for new-squad cost and the selling value preserved for existing transfer affordability behavior.
+- AE4. **Covers R11, R14.** Given a player has fplreview points for the configured gameweeks, when the player is imported, then those values become the weekly score fields used by scoring without local projection adjustment.
+- AE5. **Covers R16, R17.** Given the committed synthetic fixture, when import tests run, then they verify required-column validation and internal field mapping without requiring a legal 15-player optimizer corpus.
+
+---
+
+## Scope Boundaries
+
+- Current-squad import, manager-team sync, and replacement of hard-coded current-squad behavior are deferred.
+- CLI input configuration, random seed controls, and generation-limit controls are deferred.
+- End-to-end GA smoke testing from a full fplreview fixture is deferred.
+- Refactoring the optimizer around a new projection model is out of scope for this change.
+- Live FPL API integration is out of scope for this change.
+
+---
+
+## Dependencies and Assumptions
+
+- fplreview exports remain CSV files with player details, buying/selling price, expected value, expected minutes, and gameweek breakdown columns.
+- The implementation can identify stable fplreview column names for player ID, name, team, position, buying value, selling value, and gameweek points.
+- Existing hard-coded `gameweek` and `forecastweeks` settings remain the source of truth for which gameweek point columns are required.
+- The old internal representation is still sufficient for the current GA and scoring logic once fplreview fields are mapped into it.
+
+---
+
+## Sources
+
+- Ideation seed: `docs/ideation/2026-06-02-repo-improvements-ideation.md`
+- Existing runtime docs: `README.md`
+- Current loader and scoring code: `code/fpl.py`
+- Current runner: `code/GA.py`
+- Existing smoke tests: `tests/test_fpl_smoke.py`
+- fplreview export docs: https://docs.fplreview.com/the-model/planner-interface/export_projections/
+- fplreview upload docs: https://docs.fplreview.com/the-model/planner-interface/upload_projections/

--- a/docs/ideation/2026-06-02-repo-improvements-ideation.md
+++ b/docs/ideation/2026-06-02-repo-improvements-ideation.md
@@ -1,0 +1,194 @@
+---
+date: 2026-06-02
+topic: repo-improvements
+focus: potential improvements for FPLgen
+mode: repo-grounded
+---
+
+# Ideation: Repo Improvements for FPLgen
+
+## Grounding Context
+
+FPLgen is a small Python project for generating Fantasy Premier League squads with a genetic algorithm. The core behavior is concentrated in `code/fpl.py`, with GA orchestration in `code/GA.py`, `code/Algorithm.py`, `code/Population.py`, and `code/Individual.py`.
+
+The README documents three runtime inputs under `data/`: `playerdata`, `fixturedata`, and `playerlast10.csv`. These files are intentionally not committed. The repo is old enough that the Fantasy Premier League APIs and surrounding data ecosystem have changed since the original implementation, so preserving the old scraper-shaped data contract is less useful than moving to a current import path.
+
+The preferred data direction is to import from a single file exported from fplreview.com. There is a GitHub issue posted for this change, although this pass could not verify the issue number because GitHub API access was unavailable in the sandbox. Current tests cover path resolution and a few `validteam()` cases, but they do not exercise file import, projections, scoring, transfers, or GA evolution.
+
+Notable constraints and pain points:
+
+- `fpl.py` holds global mutable state for players, fixtures, budget, gameweek, forecast weeks, chips, and transfer behavior.
+- `getplayerdata()` expects older scraper-shaped inputs and writes `data/playerkeydata` as a side effect.
+- `lookaheadpoints()` indexes fixtures with `fixtures[player["id"] - 1]`, so player IDs and fixture rows must stay aligned.
+- The most useful data contract improvement is likely a new single-file fplreview.com importer rather than a compatibility layer around the old three-file scraper input.
+- `GA.py` runs work at import time, creates a population of 10,000, and loops up to 300 generations with no CLI controls.
+- `Population.get_average_fitness()` reads cached scores directly, which can include `-1` for unevaluated individuals unless fitness was computed first.
+- The repo already has a recent ideation note for a synthetic test data set; that note is treated as background context here.
+
+External context: current FPL tooling commonly documents `bootstrap-static` for player data and `element-summary/{player_id}` for per-player fixtures/history, while this repo expects a three-file scraper-shaped contract. fplreview.com-style projections are also used by adjacent FPL optimization tools as loadable projection data. Useful references include the `fpl` package docs, FPLstat's data reference, Oliver Looney's FPL API explainer, and FPL Optimized's load-data page:
+
+- https://fpl.readthedocs.io/en/latest/_modules/fpl/fpl.html
+- https://james-leslie.github.io/fplstat/data-reference/
+- https://www.oliverlooney.com/blogs/FPL-APIs-Explained
+- https://fploptimized.com/load.html
+
+## Topic Axes
+
+- Data contract and fixtures
+- Scoring correctness
+- GA runtime and reproducibility
+- State and architecture
+- Developer workflow and packaging
+
+## Ranked Ideas
+
+### 1. Import a Single fplreview.com Export File
+
+**Description:** Replace the old three-file runtime import path with a single-file importer for fplreview.com exports. The importer should normalize the exported player projections into the internal shape needed for squad generation, scoring, transfer planning, and inspection output. Use the posted GitHub issue as the implementation brief once its exact fields and acceptance criteria are available.
+
+**Axis:** Data contract and fixtures
+
+**Basis:** `direct:` The repo currently expects old scraper-shaped inputs, and the user clarified that the FPL APIs have changed since the project was written and that a GitHub issue now asks for import from a single fplreview.com export file.
+
+**Rationale:** This is now the highest-leverage move because it updates the project around the data source Mark actually wants to use. It reduces dependency on stale API/scraper assumptions and gives the rest of the optimizer a cleaner, current input contract.
+
+**Downsides:** Requires a representative fplreview.com export sample and a decision on which columns become the internal projection fields.
+
+**Confidence:** 95%
+
+**Complexity:** Medium
+
+**Status:** Explored
+
+### 2. Build a Golden fplreview.com Import Fixture
+
+**Description:** Add a small representative fplreview.com export under `tests/fixtures/` and use it to test import, normalization, projection fields, unavailable or low-minutes players, and a known legal squad. Keep any synthetic data in the same column shape as the real export rather than recreating the old `playerdata`/`fixturedata`/`playerlast10.csv` trio.
+
+**Axis:** Data contract and fixtures
+
+**Basis:** `direct:` Existing tests do not exercise runtime data import, and the desired future import surface is a single fplreview.com export file.
+
+**Rationale:** A golden fixture lets the project change data import without guessing. It should also become the safety net for scoring and GA smoke tests.
+
+**Downsides:** Needs either a committed sanitized sample or a generator that faithfully mimics the export columns.
+
+**Confidence:** 93%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 3. Add a Reproducible, Configurable GA Runner
+
+**Description:** Replace the hard-coded script behavior in `GA.py` with a small CLI entrypoint that accepts the fplreview.com export path, population size, generation limit, random seed, gameweek, and forecast weeks. Keep current defaults available only where they still make sense, but make short deterministic runs possible for tests and debugging.
+
+**Axis:** GA runtime and reproducibility
+
+**Basis:** `direct:` `GA.py` immediately imports player data, creates `Population(10000, True)`, and loops until generation 300 or an unreachable-looking max fitness target.
+
+**Rationale:** A configurable runner makes the project usable with a real fplreview.com export and with tiny fixtures. It also lets future work compare optimizer changes with the same seed instead of guessing whether a score changed because of randomness.
+
+**Downsides:** Needs modest restructuring to avoid breaking `python3 code/GA.py`.
+
+**Confidence:** 90%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 4. Split Import, Projection, and Scoring Into Explicit Boundaries
+
+**Description:** Separate the new fplreview.com file import, projection normalization, scoring inputs, and inspection output into distinct functions or objects. This can be a stepping stone toward an `FplContext` that owns players, budget, gameweek, chip flags, and scoring constants.
+
+**Axis:** State and architecture
+
+**Basis:** `direct:` `getplayerdata()` currently mixes file IO, field enrichment, projection calculations, global assignment, and writing `playerkeydata`, while `fpl.py` defines many module globals for run state.
+
+**Rationale:** The fplreview.com import change is a natural moment to stop mixing data acquisition with scoring behavior. A boundary-first refactor reduces hidden coupling without requiring a full rewrite.
+
+**Downsides:** Needs discipline to keep the first pass narrow; a full context rewrite is tempting but should be staged.
+
+**Confidence:** 86%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 5. Lock Down Scoring and Transfer Edge Cases
+
+**Description:** Add focused tests for scoring formation selection, captain/triple-captain behavior, bench boost, unavailable players or low projected minutes, blank or missing projection weeks, budget-constrained transfers, and invalid teams returning zero. Use builders plus the fplreview.com golden fixture rather than live API data.
+
+**Axis:** Scoring correctness
+
+**Basis:** `direct:` `scoreteam()` mutates transfer patterns and bank state, `score()` chooses a starting lineup from sorted weekly projections, and the future importer will need to map fplreview.com projection columns into the week scores that scoring expects.
+
+**Rationale:** The scoring logic is where domain value lives, but today it is mostly unprotected. These tests would let the project improve optimizer mechanics without accidentally changing FPL rules.
+
+**Downsides:** Requires deciding whether current behavior is intended in places where code comments and live behavior diverge.
+
+**Confidence:** 87%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 6. Add Validity Repair Instead of Letting Broken Individuals Score Zero
+
+**Description:** Implement or replace `repairteam()` so crossover and mutation produce valid squads more often, or make mutation position-aware enough to preserve squad shape, budget, club limits, and uniqueness. Track invalid-rate during evolution as a metric.
+
+**Axis:** GA runtime and reproducibility
+
+**Basis:** `direct:` `Algorithm.evolve_population()` has repair logic commented out, `repairteam()` currently returns the team unchanged, and `scoreteam()` returns zero for invalid teams.
+
+**Rationale:** If many evolved individuals are invalid, the GA spends search budget rediscovering legality instead of improving team quality. A repair or constraint-preserving mutation step could improve convergence without changing the scoring model.
+
+**Downsides:** Needs measurement first; a naive repair function could bias the search or hide invalid-generation bugs.
+
+**Confidence:** 78%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 7. Modernize the Developer Workflow Around Import-and-Run
+
+**Description:** Add a proper console script, test command, lint/format baseline, and README examples for running against a fplreview.com export. Keep the implementation plain Python, but make `fplgen --input path/to/export.csv --seed 1 --generations 20` style workflows obvious.
+
+**Axis:** Developer workflow and packaging
+
+**Basis:** `direct:` `pyproject.toml` exists with project metadata and pytest pythonpath, but the README still points to `python3 code/GA.py` and there is no packaged entrypoint.
+
+**Rationale:** This is a low-risk way to make the repo easier to run, test, and extend around the new data source. It also creates a natural home for configuration once the GA runner becomes parameterized.
+
+**Downsides:** Lower algorithmic value than test/scoring work; should not distract from data contract improvements.
+
+**Confidence:** 84%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Replace the GA with an integer-programming optimizer | Interesting external direction, but too close to replacing the subject rather than improving this GA repo. |
+| 2 | Update the repo to call current FPL APIs directly | Less useful than the stated target: import from a single fplreview.com export file. |
+| 3 | Add a web dashboard | Too expensive relative to current repo maturity; the run/data/scoring surface needs stabilization first. |
+| 4 | Convert everything to pandas | Could help analysis, but no direct basis that tabular processing is the current bottleneck. |
+| 5 | Preserve the old three-file scraper contract as the primary path | The repo's age and changed FPL APIs make this lower value than moving to fplreview.com import. |
+| 6 | Tune mutation/crossover constants immediately | Premature without reproducible seeds, invalid-rate metrics, and scoring regression tests. |
+| 7 | Delete legacy comments and constants as cleanup | Below the meeting-test floor as a standalone repo improvement, though it can accompany deeper refactors. |
+| 8 | Switch from unittest to pytest wholesale | Not enough value by itself; the current test framework works for the next set of regression tests. |
+| 9 | Add type hints everywhere | Useful eventually, but too broad; stronger if scoped to the data adapter/context work. |
+
+## Recommendation
+
+Start with Ideas 1, 2, 3, and 5 as the first improvement wave:
+
+1. Define and implement the single-file fplreview.com export importer.
+2. Add a golden fplreview.com import fixture.
+3. Add deterministic short-run controls to the GA entrypoint.
+4. Cover the scoring and transfer rules that matter most.
+
+Those moves create enough safety to tackle the larger architectural improvements: boundary-first refactor, context object, and validity repair.

--- a/docs/ideation/test-data-set-2026-06-02.md
+++ b/docs/ideation/test-data-set-2026-06-02.md
@@ -1,0 +1,132 @@
+# Test Data Set Ideation: FPLgen
+
+Date: 2026-06-02
+
+## Topic
+
+How to create a test data set for this repository.
+
+## Grounding
+
+FPLgen expects runtime data in three files under `data/`: `playerdata`, `fixturedata`, and `playerlast10.csv`. Those files are intentionally not committed. The current committed test coverage uses in-memory player dictionaries and only checks path handling plus `validteam` basics.
+
+Important code constraints:
+
+- `getplayerdata()` loads `playerdata` as JSON, `playerlast10.csv` as CSV, and `fixturedata` as newline-delimited JSON.
+- `fixturedata` is accessed by `fixtures[player["id"] - 1]`, so fixture records must align with contiguous player IDs unless the loader changes.
+- `lookaheadpoints()` needs each fixture record to include `history_past` and `fixtures`.
+- `validteam()` enforces 15-player squad shape, max 3 per club, unique player IDs, budget, and a stricter no-duplicate-club-per-position rule.
+- `generateteam()` uses global `players` and random selection, so a test corpus needs enough available players by position and club to avoid retry loops.
+
+External context checked: Fantasy Premier League data ecosystems commonly derive from FPL API-style player, fixture, and per-player detail data; the related project in this repo is `markbarrington/fplscraper`, but the local loader defines the exact contract this test data must satisfy.
+
+## Ranked Ideas
+
+### 1. Generated Minimal Golden Corpus
+
+Create a script or fixture helper that generates a compact, deterministic dataset into `tests/fixtures/minimal/`:
+
+- `playerdata`: 24 to 32 synthetic players with contiguous IDs, stable codes, costs, positions, teams, statuses, minutes, total points, and fixture history fields.
+- `fixturedata`: one newline-delimited JSON record per player ID with `history_past` and six future `fixtures`.
+- `playerlast10.csv`: rows keyed by player code, including home and away scoring aggregates.
+
+This is the strongest option because it matches the real loader surface while keeping the data small, readable, and reproducible. It can support tests for `getplayerdata()`, `lookaheadpoints()`, `scoreteam()`, and a small deterministic `Population` run.
+
+Tradeoff: the generator must encode the old data shape carefully, but that is also valuable documentation.
+
+### 2. Two-Tier Fixtures: Unit Builders Plus Integration Corpus
+
+Keep the lightweight in-memory builders already used by smoke tests, but add a file-backed corpus for loader and scoring tests.
+
+Use:
+
+- `tests/helpers.py` for player/team builders.
+- `tests/fixtures/minimal/` for realistic file inputs.
+- Tests that copy or point loader resolution at the fixture directory without polluting `data/`.
+
+This gives the best day-to-day ergonomics. Unit tests stay fast and obvious; integration tests prove the data-file contract still works.
+
+Tradeoff: needs a small amount of test harness work because `data_file()` currently searches fixed locations.
+
+### 3. Contract Snapshot From `fplscraper`
+
+Capture one tiny representative output from the related scraper project and trim it to a stable subset.
+
+This would reveal mismatches between FPLgen and scraper output better than fully synthetic data, especially around field names and row ordering.
+
+Tradeoff: real-world snapshots can become noisy, may carry licensing or freshness questions, and can obscure intent if every field is preserved.
+
+### 4. Scenario Matrix Corpus
+
+Create several named mini-datasets, each targeting one behavior:
+
+- `happy_path`: enough available players for a valid squad and six scored gameweeks.
+- `unavailable_players`: verifies unavailable players are zeroed.
+- `blank_fixture`: verifies a player with no fixture does not crash scoring.
+- `double_gameweek`: verifies multiple fixtures in one event add points.
+- `budget_pressure`: verifies generation/scoring around tight costs.
+- `non_contiguous_ids`: intentionally fails or documents the current fixture indexing limitation.
+
+This is excellent for regression testing once the first corpus exists.
+
+Tradeoff: more files and more maintenance. Better as a second wave than the first move.
+
+### 5. Property-Style Synthetic Dataset Factory
+
+Build a configurable factory that can generate many legal FPL-like player pools with seeded randomness, then assert invariants such as "generated teams are always 15 players" or "scoreteam never raises for legal fixture sets."
+
+This could expose edge cases in the random GA flow.
+
+Tradeoff: too much machinery for the repo's current test depth. It should follow a fixed golden corpus, not precede it.
+
+## Rejected Ideas
+
+### Commit Full Real Runtime Data
+
+Rejected because the README says runtime data is intentionally kept out of Git, and large/live FPL data would make tests brittle.
+
+### Use Only In-Memory Dictionaries
+
+Rejected as the primary strategy because it would not exercise the file contract, CSV parsing, fixture ordering, or `playerkeydata` output.
+
+### Mock `getplayerdata()` Heavily
+
+Rejected because the loader is exactly where the risk is. Mocking it would bypass the most fragile integration point.
+
+### Download Live FPL Data During Tests
+
+Rejected because tests should be deterministic, offline, and independent of current season API shape.
+
+## Recommendation
+
+Start with Idea 1 plus the useful parts of Idea 2:
+
+1. Add `tests/fixtures/minimal/` with a generated golden corpus.
+2. Add a fixture helper that temporarily points data loading at that directory or copies files into a temporary data directory.
+3. Add tests for:
+   - `getplayerdata()` loads all three inputs and writes `playerkeydata`.
+   - every loaded player receives `lookaheadpoints`, `thisweekpoints`, `ppg`, and week keys `1` through `6`.
+   - unavailable players get zero projected week scores.
+   - a known legal squad scores above zero.
+   - a tiny seeded population can be created without hanging or returning malformed individuals.
+
+The first corpus should be synthetic, not live data. Use club and player names that make intent obvious, keep player IDs contiguous, and preserve the old FPL/scraper-shaped fields that the code currently expects.
+
+## Suggested Dataset Shape
+
+Minimum practical corpus:
+
+- 28 players:
+  - 4 goalkeepers
+  - 8 defenders
+  - 10 midfielders
+  - 6 forwards
+- 10 to 12 clubs represented, with no more than 3 players per club in any intended legal squad.
+- Costs mostly 45 to 75, with one expensive scenario set.
+- At least one unavailable player per position.
+- Six future fixtures per player covering gameweeks 3 through 8, matching the current `gameweek = 3` and `forecastweeks = 6`.
+- `history_past` includes a `2015/16` row, even if current gameweek scoring dominates at the moment.
+
+## Next Step
+
+Run `ce-brainstorm` on the selected direction, likely "Generated Minimal Golden Corpus", to define the exact fixture schema, test harness changes, and naming before implementation.

--- a/docs/plans/2026-06-02-001-feat-fplreview-import-plan.md
+++ b/docs/plans/2026-06-02-001-feat-fplreview-import-plan.md
@@ -1,0 +1,263 @@
+---
+title: "feat: Import fplreview CSV projections"
+type: feat
+status: completed
+date: 2026-06-02
+origin: docs/brainstorms/2026-06-02-fplreview-import-requirements.md
+---
+
+# feat: Import fplreview CSV projections
+
+## Summary
+
+Replace FPLgen's old three-file runtime data import with a single fplreview.com CSV at `data/fplreview.csv`. The implementation should map fplreview fields into the existing internal player shape so current squad generation, scoring, transfers, and inspection output can keep working with minimal downstream logic change.
+
+---
+
+## Problem Frame
+
+The repo currently imports `playerdata`, `fixturedata`, and `playerlast10.csv`, then calculates local projections in `code/fpl.py`. The requirements doc establishes that this old data path no longer matches the preferred workflow: fplreview projections should become the source of truth, and `GW_Pts` values should be used directly as expected points for each configured gameweek.
+
+The key implementation challenge is compatibility. FPLgen's GA and scoring code expect player dictionaries with fields such as `id`, `code`, `second_name`, `team`, `team_name`, `element_type`, `now_cost`, `sellprice`, `status`, weekly string keys, `lookaheadpoints`, `thisweekpoints`, `ppg`, and `otherteams`. The plan should preserve those expectations while changing where the data comes from.
+
+---
+
+## Requirements
+
+**Input and validation**
+
+- R1. FPLgen reads runtime projection data from `data/fplreview.csv`.
+- R2. The importer validates that the CSV has player identity, team, position, buying value, selling value, and configured gameweek points.
+- R3. Missing required fields or configured gameweek columns fail fast before optimizer work begins.
+- R4. All imported players are internally available because fplreview expected points already include availability and expected-minutes effects.
+
+**Mapping and compatibility**
+
+- R5. fplreview fields are mapped into the existing internal player dictionary shape.
+- R6. fplreview position and team values are normalized into the existing position and team representations used by validation and scoring.
+- R7. `BV` maps to the internal buying cost used by new squad generation.
+- R8. `SV` is preserved as the internal selling price used by existing transfer affordability logic.
+- R9. Configured gameweek point columns map directly to internal week score fields without local projection adjustment.
+- R10. Existing scoring, squad generation, transfer, chip, budget, and validity behavior remain unchanged except for small compatibility changes needed to consume mapped fplreview players.
+
+**Inspection, tests, and docs**
+
+- R11. `playerkeydata` continues to be written and reflects loaded fplreview values.
+- R12. A committed synthetic fplreview-format CSV fixture covers import and mapping behavior without needing a legal optimizer-sized player pool.
+- R13. README documentation describes `data/fplreview.csv` as the normal runtime input and stops presenting the old three-file flow as the standard path.
+
+---
+
+## Key Technical Decisions
+
+- **Thin adapter over application rewrite:** Implement fplreview parsing and validation at the import boundary, then feed mapped player dictionaries to existing logic. This directly follows the requirements' minimum-change constraint.
+- **Keep `fpl.getplayerdata()` as the public loading entrypoint:** `code/GA.py` already calls `fpl.getplayerdata()`. Keeping that entrypoint avoids a runner change and confines most work to loader behavior.
+- **Factor parsing into testable helpers:** The loader should delegate CSV reading, validation, and row mapping to focused helpers so tests can exercise import behavior without running `GA.py` or building a valid full squad.
+- **Column handling is a compatibility contract:** fplreview docs name fields such as `Pos`, `ID`, `Name`, `BV`, `SV`, `Team`, and gameweek `GW_xMins` / `GW_Pts` style fields. Keep column-name matching centralized so future fplreview format tweaks do not spread through scoring code.
+- **Do not call `lookaheadpoints()` for fplreview imports:** Weekly point fields, `lookaheadpoints`, `thisweekpoints`, and `ppg` should be derived directly from imported CSV values, not from the old fixture/history projection path.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  CSV["data/fplreview.csv"] --> Read["Read CSV rows"]
+  Read --> Validate["Validate required identity, price, team, position, and gameweek columns"]
+  Validate --> Map["Map each row to current FPLgen player dictionary"]
+  Map --> Globals["Assign fpl.players for existing GA/scoring code"]
+  Map --> Inspect["Write data/playerkeydata inspection output"]
+  Globals --> Existing["Existing squad generation, transfer, validation, and scoring"]
+```
+
+The importer is the compatibility layer. Everything downstream should see ordinary FPLgen-style players with weekly score fields already populated.
+
+---
+
+## Implementation Units
+
+### U1. Add fplreview import helpers
+
+**Goal:** Create a focused import boundary that can read, validate, and map fplreview CSV rows without invoking the GA.
+
+**Files:**
+
+- `code/fpl.py`
+- `tests/test_fplreview_import.py`
+- `tests/fixtures/fplreview_minimal.csv`
+
+**Approach:**
+
+- Add a small set of helper functions or static methods near the current loader code for:
+  - resolving `data/fplreview.csv`
+  - reading CSV rows with headers
+  - validating required base columns
+  - deriving the required configured gameweek point columns from `gameweek` and `forecastweeks`
+  - mapping one CSV row into a current internal player dictionary
+- Keep helpers simple and local to the current code style unless implementation reveals that a separate module would reduce coupling without expanding scope.
+- Represent imported players as available by setting `status` to `"a"`.
+- Populate compatibility fields needed by current code: player identity, `code`, `second_name`, `team`, `team_name`, `element_type`, `now_cost`, `sellprice`, `picked`, `total_points`, `minutes`, `tsp`, `ppg`, `thisweekpoints`, `lookaheadpoints`, weekly string keys, and `otherteams`.
+- For `otherteams`, use placeholder values that preserve scoring behavior without reintroducing fixture dependency. Existing scoring checks only need list entries by week to avoid indexing errors and conflict checks.
+
+**Execution note:** Build this test-first around the synthetic fixture and missing-column cases before replacing the runtime loader.
+
+**Test scenarios:**
+
+- Importing the synthetic fixture returns one mapped player per CSV row with expected internal keys.
+- A row with `BV` maps to `now_cost`; a row with `SV` maps to `sellprice`.
+- Position values map to the existing `element_type` representation for goalkeeper, defender, midfielder, and forward.
+- Team values map to internal `team` and `team_name` values consistently enough for `validteam()` and `teamvalue()` to operate.
+- Missing a required base column raises a clear import error.
+- Missing one configured gameweek point column raises before any mapped players are returned.
+
+**Requirements covered:** R1-R9, R12
+
+### U2. Replace the runtime loader with fplreview CSV import
+
+**Goal:** Make `fpl.getplayerdata()` load `data/fplreview.csv` and stop depending on `playerdata`, `fixturedata`, or `playerlast10.csv`.
+
+**Files:**
+
+- `code/fpl.py`
+- `tests/test_fplreview_import.py`
+
+**Approach:**
+
+- Update `getplayerdata()` so it resets global `players` and `fixtures`, imports fplreview rows through the helper boundary, assigns the mapped players to global `players`, and writes `playerkeydata`.
+- Do not load or parse old runtime files in the normal path.
+- Do not call `lookaheadpoints()` for imported players.
+- Keep old projection helpers in place if deleting them would increase blast radius; they can become legacy/deferred cleanup after the fplreview path is stable.
+- Ensure import failure occurs before partial global state is left behind.
+
+**Execution note:** Characterize the current `getplayerdata()` side effects first: global reset, `playerkeydata` write, and player field expectations. Then swap the data source while preserving side effects.
+
+**Test scenarios:**
+
+- Calling `getplayerdata()` with a temporary fplreview CSV populates `fpl.players` with mapped players.
+- Calling `getplayerdata()` no longer requires `playerdata`, `fixturedata`, or `playerlast10.csv`.
+- Failed import from a malformed CSV leaves no partially usable imported player list.
+- Imported weekly scores are unchanged from CSV values; no local projection adjustment is applied.
+
+**Requirements covered:** R1, R3-R5, R9-R11
+
+### U3. Preserve scoring and transfer compatibility
+
+**Goal:** Verify that mapped fplreview players can be consumed by current scoring-adjacent behavior without changing optimizer logic.
+
+**Files:**
+
+- `code/fpl.py`
+- `tests/test_fplreview_import.py`
+- `tests/test_fpl_smoke.py`
+
+**Approach:**
+
+- Add targeted tests against mapped fixture players rather than a full GA corpus.
+- Exercise `teamvalue()` and `validteam()` using imported/mapped player dictionaries where practical.
+- Verify transfer-price compatibility at the data-shape level: outgoing players expose `sellprice`, incoming players expose `now_cost`.
+- Avoid rewriting `scoreteam()`, `transfer()`, `generateteam()`, or `Algorithm` unless tests reveal a direct compatibility break from the mapped fields.
+
+**Test scenarios:**
+
+- A mapped player contributes `BV` through `teamvalue()`.
+- A mapped player exposes `sellprice` from `SV`.
+- A small constructed squad using mapped player dictionaries can pass or fail `validteam()` for the same reasons as current hand-built dictionaries.
+- Imported players have `status = "a"` and are not filtered out by generation/scoring availability checks.
+
+**Requirements covered:** R4-R10
+
+### U4. Update `playerkeydata` inspection output
+
+**Goal:** Keep `data/playerkeydata` as a generated inspection artifact, but make it reflect fplreview-loaded values.
+
+**Files:**
+
+- `code/fpl.py`
+- `tests/test_fplreview_import.py`
+
+**Approach:**
+
+- Preserve the existing write path through `data_file("playerkeydata", for_write=True)`.
+- Keep the output useful for checking imported player name, team, position, price, this-week points, lookahead points, and weekly point fields.
+- Do not attempt to explain projection components that no longer exist in the fplreview import path.
+
+**Test scenarios:**
+
+- Importing the synthetic fixture writes `playerkeydata`.
+- The inspection output contains imported weekly point values.
+- The inspection output does not depend on old fixture/history fields.
+
+**Requirements covered:** R11
+
+### U5. Refresh README and runtime data guidance
+
+**Goal:** Make the documented path match the new import contract.
+
+**Files:**
+
+- `README.md`
+
+**Approach:**
+
+- Replace the old `playerdata` / `fixturedata` / `playerlast10.csv` normal-flow instructions with `data/fplreview.csv`.
+- Explain that fplreview `GW_Pts` values are used as expected points directly.
+- Keep the quick start as `python3 code/GA.py` unless implementation changes the runner, which this plan does not require.
+- Remove or reframe the old `fplscraper` reference so readers do not treat it as the current input path.
+- Mention that `playerkeydata` remains an inspection output.
+
+**Test scenarios:**
+
+- Documentation mentions `data/fplreview.csv` as the standard runtime input.
+- Documentation no longer tells users to prepare the old three files for normal use.
+- Documentation describes `playerkeydata` consistently with its new role.
+
+**Requirements covered:** R13
+
+---
+
+## Acceptance Examples
+
+- AE1. Given `data/fplreview.csv` lacks `Pos`, import fails with a clear missing-column error before optimizer work starts.
+- AE2. Given configured `gameweek` and `forecastweeks` require six gameweek point columns and one is absent, import fails before assigning usable global player data.
+- AE3. Given a CSV row contains `BV` and `SV`, the mapped player uses `BV` as `now_cost` and preserves `SV` as `sellprice`.
+- AE4. Given a player has configured fplreview gameweek point values, the mapped weekly score fields exactly match those values and are not adjusted by old projection logic.
+- AE5. Given the committed synthetic fixture, tests verify import and mapping behavior without requiring a full 15-player legal-squad corpus.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- Current-squad import, manager-team sync, and replacement of hard-coded current-squad behavior.
+- CLI input configuration, random seed controls, and generation-limit controls.
+- End-to-end GA smoke testing from a full fplreview fixture.
+- Cleanup or deletion of old projection helpers after the new import path is stable.
+
+### Out of Scope
+
+- Live FPL API integration.
+- Rebuilding the optimizer around a new projection model.
+- Changing transfer, scoring, chip, budget, or validity rules beyond compatibility fixes needed for mapped fplreview players.
+
+---
+
+## Risks and Dependencies
+
+- **fplreview column naming drift:** The docs describe the field families, but implementation may need to confirm exact exported headers from a real CSV. Keep column matching centralized and easy to update.
+- **Team and position normalization:** The existing code relies on numeric team IDs, team names, and numeric position IDs. Mapping must be explicit enough to avoid silent bad teams.
+- **Legacy assumptions in scoring:** Some scoring paths expect `otherteams` and weekly keys to exist. The importer should populate compatibility defaults rather than broadening scoring changes.
+- **Fixture is intentionally narrow:** The synthetic fixture validates import and mapping, not full optimizer behavior. That is aligned with the requirements but should not be mistaken for end-to-end confidence.
+
+---
+
+## Sources and Research
+
+- Origin requirements: `docs/brainstorms/2026-06-02-fplreview-import-requirements.md`
+- Current loader/scoring: `code/fpl.py`
+- Current runner: `code/GA.py`
+- Path handling: `code/paths.py`
+- Existing tests: `tests/test_fpl_smoke.py`
+- Runtime docs: `README.md`
+- fplreview export docs: https://docs.fplreview.com/the-model/planner-interface/export_projections/
+- fplreview upload docs: https://docs.fplreview.com/the-model/planner-interface/upload_projections/

--- a/tests/fixtures/fplreview_minimal.csv
+++ b/tests/fixtures/fplreview_minimal.csv
@@ -1,0 +1,5 @@
+Pos,ID,Name,BV,SV,Team,3_Pts,4_Pts,5_Pts,6_Pts,7_Pts,8_Pts
+GKP,101,Alpha Keeper,4.5,4.4,Arsenal,4.1,3.9,4.0,4.2,3.8,4.3
+DEF,102,Beta Defender,5.2,5.1,Chelsea,5.0,4.8,4.7,4.9,5.1,5.2
+MID,103,Gamma Midfielder,8.0,7.9,Man City,6.2,6.4,6.1,6.3,6.5,6.6
+FWD,104,Delta Forward,7.5,7.4,Liverpool,5.5,5.7,5.6,5.8,5.9,6.0

--- a/tests/test_fplreview_import.py
+++ b/tests/test_fplreview_import.py
@@ -1,0 +1,105 @@
+import csv
+import importlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CODE_DIR = PROJECT_ROOT / "code"
+FIXTURE = PROJECT_ROOT / "tests" / "fixtures" / "fplreview_minimal.csv"
+if str(CODE_DIR) not in sys.path:
+    sys.path.insert(0, str(CODE_DIR))
+
+fpl_module = importlib.import_module("fpl")
+from fpl import fpl
+
+
+class FplReviewImportTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.data_dir = Path(self.tempdir.name)
+        self.original_data_file = fpl_module.data_file
+
+        def temp_data_file(filename, for_write=False):
+            if for_write:
+                self.data_dir.mkdir(exist_ok=True)
+            return self.data_dir / filename
+
+        fpl_module.data_file = temp_data_file
+
+    def tearDown(self):
+        fpl_module.data_file = self.original_data_file
+        self.tempdir.cleanup()
+        fpl_module.players = []
+        fpl_module.fixtures = []
+
+    def test_import_fixture_maps_core_player_fields(self):
+        players = fpl.load_fplreview_players(FIXTURE)
+
+        self.assertEqual(len(players), 4)
+        keeper = players[0]
+        self.assertEqual(keeper["id"], 101)
+        self.assertEqual(keeper["code"], 101)
+        self.assertEqual(keeper["second_name"], "Alpha Keeper")
+        self.assertEqual(keeper["team_name"], "Arsenal")
+        self.assertEqual(keeper["element_type"], 1)
+        self.assertEqual(keeper["type_name"], "Goalkeeper")
+        self.assertEqual(keeper["now_cost"], 45)
+        self.assertEqual(keeper["sellprice"], 44)
+        self.assertEqual(keeper["status"], "a")
+
+    def test_import_fixture_uses_gameweek_points_without_adjustment(self):
+        players = fpl.load_fplreview_players(FIXTURE)
+        midfielder = players[2]
+
+        self.assertEqual(midfielder["1"], 6.2)
+        self.assertEqual(midfielder["2"], 6.4)
+        self.assertEqual(midfielder["6"], 6.6)
+        self.assertEqual(midfielder["thisweekpoints"], 6.2)
+        self.assertAlmostEqual(midfielder["lookaheadpoints"], 38.1)
+        self.assertAlmostEqual(midfielder["ppg"], 38.1 / fpl_module.forecastweeks)
+
+    def test_missing_required_column_fails_fast(self):
+        with open(FIXTURE, newline="", encoding="utf-8") as fixture:
+            rows = list(csv.DictReader(fixture))
+
+        fieldnames = [field for field in rows[0].keys() if field != "Pos"]
+        with self.assertRaisesRegex(ValueError, "Missing required fplreview columns: Pos"):
+            fpl.map_fplreview_rows(rows, fieldnames)
+
+    def test_missing_configured_gameweek_column_fails_fast(self):
+        with open(FIXTURE, newline="", encoding="utf-8") as fixture:
+            rows = list(csv.DictReader(fixture))
+
+        fieldnames = [field for field in rows[0].keys() if field != "8_Pts"]
+        with self.assertRaisesRegex(ValueError, "Missing required fplreview gameweek columns: 8_Pts"):
+            fpl.map_fplreview_rows(rows, fieldnames)
+
+    def test_getplayerdata_loads_fplreview_csv_and_writes_inspection_output(self):
+        runtime_file = self.data_dir / "fplreview.csv"
+        runtime_file.write_text(FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+        fpl.getplayerdata()
+
+        self.assertEqual(len(fpl_module.players), 4)
+        self.assertEqual(fpl_module.players[1]["second_name"], "Beta Defender")
+        self.assertEqual(fpl_module.players[1]["1"], 5.0)
+
+        playerkeydata = self.data_dir / "playerkeydata"
+        self.assertTrue(playerkeydata.exists())
+        output = playerkeydata.read_text(encoding="utf-8-sig")
+        self.assertIn("Beta Defender", output)
+        self.assertIn(",5.0,4.8,4.7,4.9,5.1,5.2", output)
+
+    def test_mapped_players_keep_existing_cost_and_availability_shape(self):
+        players = fpl.load_fplreview_players(FIXTURE)
+
+        self.assertEqual(fpl.teamvalue(players), 45 + 52 + 80 + 75)
+        self.assertEqual(players[0]["sellprice"], 44)
+        self.assertTrue(all(player["status"] == "a" for player in players))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

FPLgen can now run from a single fplreview.com CSV export instead of the old three-file FPL/scraper data bundle. Imported `GW_Pts` values become the weekly expected scores directly, so the optimizer uses fplreview projections without applying the legacy local projection adjustments.

## What changed

- Replaced the runtime loader with a thin fplreview CSV adapter at `data/fplreview.csv`.
- Mapped fplreview identity, team, position, `BV`, `SV`, and configured gameweek point columns into the existing internal player shape.
- Preserved `playerkeydata` as an inspection output for loaded projection values.
- Added synthetic import fixture coverage for validation, field mapping, direct weekly point use, and test isolation from real runtime data.
- Updated README data-file guidance and included the brainstorm/plan artifacts used to shape the work.

Closes #2.

## Verification

- `python3 -m py_compile code/*.py`
- `python3 -m unittest discover -s tests`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
