### PR TITLE
feat: add configurable GA runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ The project imports fplreview.com player projection exports and searches for a h
 python3 code/GA.py
 ```
 
+The default run preserves the original production-sized search settings. For a
+short deterministic development run, pass explicit controls:
+
+```sh
+python3 code/GA.py --input tests/fixtures/fplreview_golden.csv --population 6 --generations 2 --seed 7
+```
+
+Useful runtime options include:
+
+- `--input`: fplreview CSV export path
+- `--population`: GA population size
+- `--generations`: maximum generation count
+- `--seed`: random seed for reproducible runs
+- `--gameweek`: first gameweek projection column to load
+- `--forecastweeks`: number of gameweeks to load
+
 ## Data files
 
 Runtime data is intentionally kept out of Git. Export projections from fplreview.com and save the CSV as:

--- a/code/FitnessCalc.py
+++ b/code/FitnessCalc.py
@@ -8,9 +8,8 @@ class FitnessCalc():
 
     @staticmethod
     def get_max_fitness():
-        return 10000
+        return FitnessCalc.Solution
 
     @staticmethod
     def targetValue():
         return 14
-

--- a/code/GA.py
+++ b/code/GA.py
@@ -1,55 +1,150 @@
+import argparse
+import random
+from pathlib import Path
+from time import time
+
+import fpl as fpl_module
+from Algorithm import Algorithm
 from FitnessCalc import FitnessCalc
 from Population import Population
-from Algorithm import Algorithm
-from time import time
 from fpl import fpl
+from paths import DATA_DIR
 
-# Import the player data from a file
 
-print("Importing player data")
-fpl.getplayerdata()
-print("Player data imported")
+DEFAULT_POPULATION_SIZE = 10000
+DEFAULT_GENERATION_LIMIT = 300
+DEFAULT_MAX_FITNESS = 10000
+DEFAULT_STATUS_INTERVAL = 20
+DEFAULT_INPUT = DATA_DIR / "fplreview.csv"
+DEFAULT_GAMEWEEK = fpl_module.gameweek
+DEFAULT_FORECASTWEEKS = fpl_module.forecastweeks
 
-# Time the algorithm
 
-start = time()
+def positive_int(value):
+    number = int(value)
+    if number <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return number
 
-# Set solution value higher than highest possible score.
-# Look for the best possible answer
-FitnessCalc.set_solution(10000)
 
-# Create the initial random population
-print("Creating intial population")
-my_pop = Population(10000, True)
-print("Population created")
-savedpoints = 0
-# Loop until number of generations is complete
-generation_count = 0
-while my_pop.fitness_of_the_fittest() < FitnessCalc.get_max_fitness():
-    generation_count += 1
-    print("Starting Generation %s" % generation_count)
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(
+        description="Run the FPLgen genetic algorithm against fplreview projections."
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=DEFAULT_INPUT,
+        help="Path to a fplreview CSV export.",
+    )
+    parser.add_argument(
+        "--population",
+        type=positive_int,
+        default=DEFAULT_POPULATION_SIZE,
+        help="Population size for the GA run.",
+    )
+    parser.add_argument(
+        "--generations",
+        type=positive_int,
+        default=DEFAULT_GENERATION_LIMIT,
+        help="Maximum generation count before stopping.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducible runs.",
+    )
+    parser.add_argument(
+        "--gameweek",
+        type=positive_int,
+        default=DEFAULT_GAMEWEEK,
+        help="First gameweek to load from the fplreview export.",
+    )
+    parser.add_argument(
+        "--forecastweeks",
+        type=positive_int,
+        default=DEFAULT_FORECASTWEEKS,
+        help="Number of gameweeks to load from the fplreview export.",
+    )
+    return parser.parse_args(args)
 
-    # Output the best solution every 100 generations
-    if generation_count % 20 == 0:
-        print("Outputting Current Status")
-        points = my_pop.OutputFittest()
-        #if points < savedpoints:
-        #    print "Elitism Failed"
-        #    break
-            
-    # Quit after a set number of generations
-    if generation_count == 300:
-        break
 
-    # Output current generation data and produce next generation
-    print("Average Fitness : %s" % my_pop.get_average_fitness())
-    print("Generation : %s Fittest : %s " % (generation_count, my_pop.fitness_of_the_fittest()))
-    my_pop = Algorithm.evolve_population(my_pop, generation_count)
-    print("******************************************************")
-  
-# Output algorithm run time
-finish = time()
-print ("Time elapsed : %s " % (finish - start)) 
+def apply_runtime_options(seed=None, gameweek=None, forecastweeks=None):
+    if seed is not None:
+        random.seed(seed)
+    if gameweek is not None:
+        fpl_module.gameweek = gameweek
+    if forecastweeks is not None:
+        fpl_module.forecastweeks = forecastweeks
 
-# Output the best solution found
-my_pop.OutputFittest()
+
+def run(
+    input_path=DEFAULT_INPUT,
+    population_size=DEFAULT_POPULATION_SIZE,
+    generation_limit=DEFAULT_GENERATION_LIMIT,
+    seed=None,
+    gameweek=DEFAULT_GAMEWEEK,
+    forecastweeks=DEFAULT_FORECASTWEEKS,
+    max_fitness=DEFAULT_MAX_FITNESS,
+    status_interval=DEFAULT_STATUS_INTERVAL,
+):
+    apply_runtime_options(seed=seed, gameweek=gameweek, forecastweeks=forecastweeks)
+
+    print("Importing player data")
+    fpl.getplayerdata(input_path)
+    print("Player data imported")
+
+    start = time()
+    FitnessCalc.set_solution(max_fitness)
+
+    print("Creating intial population")
+    my_pop = Population(population_size, True)
+    print("Population created")
+
+    generation_count = 0
+    while my_pop.fitness_of_the_fittest() < FitnessCalc.get_max_fitness():
+        generation_count += 1
+        print("Starting Generation %s" % generation_count)
+
+        if status_interval and generation_count % status_interval == 0:
+            print("Outputting Current Status")
+            my_pop.OutputFittest()
+
+        if generation_count == generation_limit:
+            break
+
+        print("Average Fitness : %s" % my_pop.get_average_fitness())
+        print(
+            "Generation : %s Fittest : %s "
+            % (generation_count, my_pop.fitness_of_the_fittest())
+        )
+        my_pop = Algorithm.evolve_population(my_pop, generation_count)
+        print("******************************************************")
+
+    finish = time()
+    print("Time elapsed : %s " % (finish - start))
+
+    fittest_score = my_pop.OutputFittest()
+    return {
+        "population": my_pop,
+        "generation_count": generation_count,
+        "fittest_score": fittest_score,
+        "elapsed": finish - start,
+    }
+
+
+def main(args=None):
+    options = parse_args(args)
+    run(
+        input_path=options.input,
+        population_size=options.population,
+        generation_limit=options.generations,
+        seed=options.seed,
+        gameweek=options.gameweek,
+        forecastweeks=options.forecastweeks,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/fpl.py
+++ b/code/fpl.py
@@ -513,11 +513,14 @@ class fpl():
     # Read the fplreview export into the player global variable.
     # Output a playerkeydata inspection file.
     @staticmethod
-    def getplayerdata():
+    def getplayerdata(filename=None):
         global players, fixtures
 
         fixtures = []
-        imported_players = fpl.load_fplreview_players(data_file('fplreview.csv'))
+        if filename is None:
+            filename = data_file('fplreview.csv')
+
+        imported_players = fpl.load_fplreview_players(filename)
 
         players = imported_players
         fpl.write_playerkeydata(players)
@@ -1333,7 +1336,7 @@ class fpl():
     def printteam(team,value):
 
         for player in team:
-            playerdata = player['second_name'].encode('ascii', errors='ignore')
+            playerdata = player['second_name'].encode('ascii', errors='ignore').decode('ascii')
             playerdata += "," + str(player['total_points'])
             playerdata += "," + str(player['tsp'])
             playerdata += "," + str(player['now_cost'])

--- a/docs/brainstorms/2026-06-03-configurable-ga-runner-requirements.md
+++ b/docs/brainstorms/2026-06-03-configurable-ga-runner-requirements.md
@@ -1,0 +1,115 @@
+---
+date: 2026-06-03
+topic: configurable-ga-runner
+---
+
+# Requirements: Configurable GA Runner
+
+## Summary
+
+Add command-line runtime controls to FPLgen's GA runner so normal runs remain compatible with today, while short deterministic optimizer runs become possible without editing source.
+
+---
+
+## Problem Frame
+
+FPLgen now has a current input path through a single fplreview.com-style CSV and a synthetic golden fixture that validates import, known-squad scoring, and a tiny seeded GA path. The next blocker is day-to-day operability: routine run choices still live in source code. `code/GA.py` loads data and immediately starts a production-sized search with hard-coded population and generation settings, while `code/fpl.py` holds gameweek and forecast settings as module-level values.
+
+That makes it awkward to run quick checks, compare seeded changes, or use a different projection export path. The goal of this first runner step is not to redesign FPLgen's state model, but to create a practical control surface that future work can build on.
+
+---
+
+## Key Decisions
+
+- **Compatibility first:** Running `python3 code/GA.py` with no flags should preserve today's default behavior as closely as practical: load `data/fplreview.csv`, use the current gameweek and forecast horizon, create a large population, and allow up to the current generation limit.
+- **CLI first:** The first control surface should be command-line flags. Config files, scenario files, presets, and richer run state can follow after the shape of the basic knobs is proven.
+- **Determinism is a first-class use case:** The runner should support seeded short runs so future tests, debugging, and optimizer comparisons can distinguish behavior changes from random variation.
+- **No scoring or optimizer rewrite:** This task should not change FPL scoring rules, transfer behavior, mutation/crossover strategy, or validity repair. It is about controlling an existing run.
+
+---
+
+## Requirements
+
+**Runtime controls**
+
+- R1. A no-flag run remains available through `python3 code/GA.py` and preserves the current default input path, population size, generation limit, gameweek, and forecast horizon.
+- R2. The runner accepts an input CSV path so users can run against a fplreview.com export outside the default `data/fplreview.csv` location.
+- R3. The runner accepts a population-size option for short smoke runs and longer search runs.
+- R4. The runner accepts a generation-limit option so users can run bounded jobs without editing source.
+- R5. The runner accepts a random-seed option that makes random team generation and GA evolution reproducible for the same input and settings.
+- R6. The runner accepts gameweek and forecast-window options that affect which fplreview projection columns are required and loaded for the run.
+
+**Run behavior**
+
+- R7. The runner reports enough progress to show data import, population creation, generation progress, elapsed time, and the final fittest result.
+- R8. The generation loop stops when either the max-fitness target is reached or the configured generation limit is reached.
+- R9. Short deterministic runs should be practical for development, such as a tiny population and a few generations against the committed golden fixture.
+- R10. Invalid or malformed runtime options fail before optimizer work begins with clear user-facing feedback.
+
+**Compatibility and documentation**
+
+- R11. Existing GA, scoring, import, transfer, and inspection-output behavior remain unchanged except where needed to respect the new runtime controls.
+- R12. README guidance includes examples for the default run and a short seeded run.
+- R13. Tests cover argument/control behavior and at least one tiny deterministic runner path without invoking a production-sized search.
+
+---
+
+## Key Flows
+
+- F1. Default production-shaped run
+  - **Trigger:** A user runs `python3 code/GA.py` with no flags.
+  - **Steps:** FPLgen loads the default fplreview CSV, creates the default large population, runs up to the default generation limit, and outputs the final fittest result.
+  - **Outcome:** Existing usage continues to work.
+  - **Covered by:** R1, R7, R8, R11, R12
+
+- F2. Short deterministic development run
+  - **Trigger:** A developer passes a custom input path, small population, short generation limit, and seed.
+  - **Steps:** FPLgen applies the provided controls, imports the selected projection CSV, runs a bounded seeded search, and outputs the final fittest result.
+  - **Outcome:** The developer can reproduce the same run for debugging or comparison.
+  - **Covered by:** R2, R3, R4, R5, R7, R8, R9, R13
+
+- F3. Alternate projection horizon run
+  - **Trigger:** A user passes gameweek and forecast-window options for a different fplreview export horizon.
+  - **Steps:** FPLgen applies the selected horizon before import, validates that the required projection columns exist, and runs using those imported weekly scores.
+  - **Outcome:** Users can run current-week scenarios without editing `code/fpl.py`.
+  - **Covered by:** R6, R10, R11
+
+---
+
+## Acceptance Examples
+
+- AE1. Given the default runtime data exists, when a user runs `python3 code/GA.py` with no flags, then FPLgen uses the same default population size, generation limit, gameweek, forecast horizon, and input path as the current script.
+- AE2. Given a committed fplreview-style fixture, when a developer runs a tiny seeded job with a custom input path, small population, and short generation limit, then the runner completes without invoking the production-sized defaults.
+- AE3. Given the same input CSV and seed, when the same short runner command is executed twice, then the random setup and resulting search path are reproducible enough for development comparison.
+- AE4. Given the selected gameweek and forecast window require a missing fplreview projection column, when the runner starts, then it fails before optimizer work begins with a clear missing-column error.
+- AE5. Given an invalid population size or generation limit, when the runner starts, then it fails before import or evolution begins.
+
+---
+
+## Scope Boundaries
+
+- Config files, scenario files, named presets, and CLI-over-config overrides are deferred.
+- A typed `RunConfig` object and broader `FplContext` state model are deferred.
+- Historical real-data fixtures from theFPLkiwi or fplcache are deferred.
+- Validity repair, mutation/crossover tuning, and scoring or transfer rule changes are out of scope for this task.
+- Packaging a console script such as `fplgen` is optional future workflow polish; this task can continue to use `python3 code/GA.py`.
+
+---
+
+## Dependencies / Assumptions
+
+- The existing fplreview importer can continue to be the runtime data source.
+- Gameweek and forecast controls will initially work with the current module-level settings rather than requiring a full state-management redesign.
+- The committed golden fixture remains the best development fixture for tiny deterministic runner validation.
+
+---
+
+## Sources / Research
+
+- `docs/ideation/2026-06-02-repo-improvements-ideation.md`
+- `docs/ideation/2026-06-02-hardcoded-elements-config-ideation.md`
+- `docs/plans/2026-06-02-001-feat-fplreview-import-plan.md`
+- `docs/plans/2026-06-02-002-feat-golden-fplreview-fixture-plan.md`
+- `code/GA.py`
+- `code/fpl.py`
+- `tests/test_fplreview_golden.py`

--- a/docs/plans/2026-06-03-001-feat-configurable-ga-runner-plan.md
+++ b/docs/plans/2026-06-03-001-feat-configurable-ga-runner-plan.md
@@ -1,0 +1,208 @@
+---
+title: "feat: Add configurable GA runner"
+type: feat
+status: completed
+date: 2026-06-03
+origin: docs/brainstorms/2026-06-03-configurable-ga-runner-requirements.md
+---
+
+# feat: Add Configurable GA Runner
+
+## Summary
+
+Add a testable command-line runner for FPLgen that preserves today's no-flag GA behavior while allowing short deterministic runs through explicit runtime options.
+
+---
+
+## Problem Frame
+
+FPLgen has moved to a single fplreview.com-style CSV input and now has a synthetic golden fixture that proves the current import-to-GA path can work. The remaining friction is that routine run controls still require source edits. `code/GA.py` runs immediately at import time, always loads the default runtime CSV, creates a production-sized population, and stops only after the current hard-coded generation limit or max-fitness target.
+
+The plan is to make the runner callable and configurable without changing FPL scoring, transfer behavior, mutation, crossover, or broader state architecture. This is a narrow control-surface improvement that sets up later `RunConfig` and `FplContext` work without doing that larger refactor now.
+
+---
+
+## Requirements
+
+**CLI controls**
+
+- R1. Running `python3 code/GA.py` with no flags preserves the current default input path, population size, generation limit, gameweek, and forecast horizon.
+- R2. The runner accepts an input CSV path for fplreview-style exports outside `data/fplreview.csv`.
+- R3. The runner accepts population-size and generation-limit options for bounded runs.
+- R4. The runner accepts a random seed option that makes the random GA path reproducible for the same input and settings.
+- R5. The runner accepts gameweek and forecast-window options that affect the fplreview projection columns loaded for the run.
+
+**Run behavior**
+
+- R6. The runner reports import, population creation, generation progress, elapsed time, and final fittest output.
+- R7. The generation loop stops when either the max-fitness target is reached or the configured generation limit is reached.
+- R8. Invalid runtime options fail before import, population creation, or evolution begins.
+- R9. Missing projection columns for the selected gameweek and forecast window fail before optimizer work begins.
+
+**Compatibility and verification**
+
+- R10. Existing GA, scoring, import, transfer, and inspection-output behavior remain unchanged except where needed to respect runtime controls.
+- R11. Tests cover argument parsing, invalid controls, custom input loading, and a tiny deterministic runner path.
+- R12. README guidance shows both the default run and a short seeded run.
+
+---
+
+## Key Technical Decisions
+
+- **Callable runner before script entrypoint:** Move the executable behavior behind a callable runner function, then have the script entrypoint delegate to it. This prevents tests from importing a production-sized run and gives later workflow work a stable seam to reuse.
+- **Compatibility defaults stay in the runner:** Keep today's values as explicit defaults in the runner contract: default fplreview input, population size `10000`, generation limit `300`, current gameweek, current forecast horizon, and max-fitness target `10000`.
+- **Path-taking import for custom inputs:** Use the existing fplreview path-taking importer for custom input paths and preserve generated `playerkeydata` inspection output after loading. The default path can continue to behave like current runtime loading as long as the same side effects are preserved.
+- **Narrow global bridge for gameweek and forecast:** Apply gameweek and forecast options to the existing module-level settings before importing players. This is intentionally a bridge over current global state, not a new configuration architecture.
+- **No new dependencies:** Use Python standard-library argument parsing and random seeding. The project currently has no runtime dependencies, and this feature does not need to add one.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  CLI["CLI args or defaults"] --> Parse["Parse and validate runtime controls"]
+  Parse --> Apply["Apply seed and projection horizon"]
+  Apply --> Import["Load fplreview players"]
+  Import --> Inspect["Write playerkeydata"]
+  Import --> Population["Create Population"]
+  Population --> Loop{"Reached target or generation limit?"}
+  Loop -->|no| Evolve["Report progress and evolve"]
+  Evolve --> Loop
+  Loop -->|yes| Output["Print elapsed time and fittest result"]
+```
+
+The important boundary is between parsing and running. Parsing produces validated runtime controls; running applies those controls to the existing FPLgen components in the same order the script currently uses.
+
+---
+
+## Implementation Units
+
+### U1. Extract a Callable Runner
+
+- **Goal:** Turn the current script behavior into a callable execution path while preserving the default run.
+- **Requirements:** R1, R6, R7, R10
+- **Dependencies:** None
+- **Files:**
+  - `code/GA.py`
+  - `tests/test_ga_runner.py`
+- **Approach:** Create a runner function that performs the current sequence: import player data, start timing, set max fitness, create the population, loop through generations, report progress, and output the fittest individual. Keep the `if __name__ == "__main__"` path as the script entrypoint so importing `code/GA.py` in tests does not start a full run.
+- **Execution note:** Add characterization-style tests before changing the runner shape enough to risk import-time side effects.
+- **Patterns to follow:** Existing `code/GA.py` ordering; direct `Population` and `Algorithm` usage in `tests/test_fplreview_golden.py`.
+- **Test scenarios:**
+  - Importing the runner module does not import player data, create a population, or print progress.
+  - Calling the runner with explicit tiny settings creates a population and returns or exposes a final fittest score above zero.
+  - Covers AE2. A tiny runner call against the golden fixture completes without using the production-sized default population or generation limit.
+- **Verification:** The old script entrypoint still runs through the same high-level stages, and tests can exercise runner behavior without triggering a production-sized search.
+
+### U2. Add CLI Parsing and Runtime Validation
+
+- **Goal:** Add command-line controls for input path, population size, generation limit, seed, gameweek, and forecast window.
+- **Requirements:** R1-R5, R8
+- **Dependencies:** U1
+- **Files:**
+  - `code/GA.py`
+  - `tests/test_ga_runner.py`
+- **Approach:** Add a small argument parser with compatibility defaults. Validate numeric options early: population size and generation limit should be positive enough to run safely, and gameweek / forecast window should be positive integers. Treat invalid options as parser-level or pre-run failures so no data import or evolution has started.
+- **Patterns to follow:** Standard-library-only project style in `pyproject.toml`; path handling style from `code/paths.py`.
+- **Test scenarios:**
+  - Parsing no arguments returns defaults matching current script behavior.
+  - Parsing custom input, population, generation limit, seed, gameweek, and forecast window returns those values.
+  - Covers AE5. Invalid population size fails before import or evolution.
+  - Covers AE5. Invalid generation limit fails before import or evolution.
+  - Invalid gameweek or forecast window fails before import or evolution.
+- **Verification:** A developer can inspect parser defaults and see no behavior drift for the no-flag run, while invalid controls fail before optimizer work.
+
+### U3. Wire Custom Input and Projection Horizon Controls
+
+- **Goal:** Make runner controls affect the imported fplreview data without introducing a full run-state architecture.
+- **Requirements:** R2, R5, R9, R10
+- **Dependencies:** U1, U2
+- **Files:**
+  - `code/GA.py`
+  - `code/fpl.py`
+  - `tests/test_ga_runner.py`
+  - `tests/test_fplreview_import.py`
+- **Approach:** Add or reuse a loading path that accepts an explicit fplreview CSV path, assigns the loaded players to the existing global player list, clears fixtures, and writes `playerkeydata`. Apply gameweek and forecast-window overrides before loading so `fplreview_gameweek_columns()` validates the correct projection columns. Keep existing `getplayerdata()` compatible for the default runtime path.
+- **Patterns to follow:** `fpl.load_fplreview_players()` and `fpl.write_playerkeydata()` in `code/fpl.py`; temporary data-file patching pattern in `tests/test_fplreview_import.py`.
+- **Test scenarios:**
+  - A runner call with a custom golden fixture path loads that file rather than `data/fplreview.csv`.
+  - A runner call with custom gameweek and forecast window loads the matching projection columns when they exist.
+  - Covers AE4. A runner call with a projection horizon requiring missing columns fails before population creation.
+  - The default loading path still writes `playerkeydata`.
+- **Verification:** The runner can operate against committed fixtures and selected projection horizons while current importer behavior remains intact.
+
+### U4. Add Seeded Deterministic Runner Coverage
+
+- **Goal:** Prove the runner can execute short reproducible GA jobs for development comparison.
+- **Requirements:** R4, R6, R7, R11
+- **Dependencies:** U1, U2, U3
+- **Files:**
+  - `tests/test_ga_runner.py`
+  - `tests/fixtures/fplreview_golden.csv`
+- **Approach:** Use the golden fixture with a tiny population, a short generation limit, and a fixed seed. Capture stdout where needed so progress logging does not make tests noisy. Assert completion and reproducible final behavior for two identical short runs. Do not assert optimizer improvement; this is a reproducibility and wiring test.
+- **Patterns to follow:** Random-state preservation and stdout capture in `tests/test_fplreview_golden.py`.
+- **Test scenarios:**
+  - Covers AE3. Two runner executions with the same fixture, seed, population, generation limit, gameweek, and forecast window produce the same final fittest score.
+  - Covers AE2. A short seeded runner path reports a nonzero fittest score.
+  - The generation loop stops at the configured generation limit when the max-fitness target is not reached.
+- **Verification:** The test suite proves the CLI runner supports repeatable short jobs without relying on production defaults.
+
+### U5. Update README Runtime Guidance
+
+- **Goal:** Document the new runner controls without making the project look more packaged than it is.
+- **Requirements:** R12
+- **Dependencies:** U1-U4
+- **Files:**
+  - `README.md`
+- **Approach:** Keep the quick start as `python3 code/GA.py`. Add an example short seeded run using the golden fixture or a custom fplreview export path, and briefly explain the flags in user-facing terms. Avoid introducing a console-script command until packaging work is explicitly in scope.
+- **Patterns to follow:** Existing concise README sections for data files and development safety checks.
+- **Test scenarios:** Test expectation: none -- README changes are verified by review, and behavioral coverage lives in `tests/test_ga_runner.py`.
+- **Verification:** A reader can identify both the default run and a small deterministic development command from the README.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- CLI controls for input path, population size, generation limit, seed, gameweek, and forecast window.
+- A callable runner seam that avoids import-time execution.
+- Tiny deterministic runner tests against the committed golden fixture.
+- README examples for default and short seeded runs.
+
+### Deferred to Follow-Up Work
+
+- Config files, scenario files, named presets, and CLI-over-config overrides.
+- A typed `RunConfig` object and broader `FplContext` state model.
+- Historical real-data fixtures from theFPLkiwi or fplcache.
+- Packaging a console script such as `fplgen`.
+- Validity repair, mutation/crossover tuning, or optimizer-quality measurement.
+
+### Out of Scope
+
+- Scoring, transfer, chip, or squad-validity rule changes.
+- Replacing the genetic algorithm with another optimizer.
+
+---
+
+## Risks & Dependencies
+
+- **Global state bridge:** Gameweek and forecast overrides currently need to update module-level values before import. Tests should restore those values after each run so state does not leak between cases.
+- **Short-run reproducibility:** GA behavior uses Python's shared random module. Runner tests should preserve and restore random state around seeded runs.
+- **Progress output coupling:** `Algorithm.evolve_population()` and `fpl.scoreteam()` print through existing paths. Tests should capture output rather than requiring this task to redesign logging.
+- **Default run cost:** The no-flag behavior intentionally remains production-sized, so automated tests must always pass explicit tiny settings.
+
+---
+
+## Sources & Research
+
+- Origin requirements: `docs/brainstorms/2026-06-03-configurable-ga-runner-requirements.md`
+- Prior ideation: `docs/ideation/2026-06-02-repo-improvements-ideation.md`
+- Prior configuration ideation: `docs/ideation/2026-06-02-hardcoded-elements-config-ideation.md`
+- Current script runner: `code/GA.py`
+- Current importer and global run settings: `code/fpl.py`
+- Current path helper: `code/paths.py`
+- Current GA components: `code/Population.py`, `code/Algorithm.py`, `code/FitnessCalc.py`
+- Existing golden fixture tests: `tests/test_fplreview_golden.py`
+- Existing fplreview import tests: `tests/test_fplreview_import.py`

--- a/tests/test_ga_runner.py
+++ b/tests/test_ga_runner.py
@@ -1,0 +1,163 @@
+import importlib
+import io
+import random
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CODE_DIR = PROJECT_ROOT / "code"
+FIXTURE = PROJECT_ROOT / "tests" / "fixtures" / "fplreview_golden.csv"
+if str(CODE_DIR) not in sys.path:
+    sys.path.insert(0, str(CODE_DIR))
+
+fpl_module = importlib.import_module("fpl")
+ga_module = importlib.import_module("GA")
+
+
+class GARunnerTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.data_dir = Path(self.tempdir.name)
+        self.original_data_file = fpl_module.data_file
+        self.original_gameweek = fpl_module.gameweek
+        self.original_forecastweeks = fpl_module.forecastweeks
+        self.random_state = random.getstate()
+
+        def temp_data_file(filename, for_write=False):
+            if for_write:
+                self.data_dir.mkdir(exist_ok=True)
+            return self.data_dir / filename
+
+        fpl_module.data_file = temp_data_file
+
+    def tearDown(self):
+        fpl_module.data_file = self.original_data_file
+        fpl_module.gameweek = self.original_gameweek
+        fpl_module.forecastweeks = self.original_forecastweeks
+        fpl_module.players = []
+        fpl_module.fixtures = []
+        random.setstate(self.random_state)
+        self.tempdir.cleanup()
+
+    def test_parse_args_uses_current_defaults(self):
+        options = ga_module.parse_args([])
+
+        self.assertEqual(options.input, ga_module.DEFAULT_INPUT)
+        self.assertEqual(options.population, 10000)
+        self.assertEqual(options.generations, 300)
+        self.assertIsNone(options.seed)
+        self.assertEqual(options.gameweek, self.original_gameweek)
+        self.assertEqual(options.forecastweeks, self.original_forecastweeks)
+
+    def test_parse_args_accepts_runtime_controls(self):
+        options = ga_module.parse_args(
+            [
+                "--input",
+                str(FIXTURE),
+                "--population",
+                "6",
+                "--generations",
+                "2",
+                "--seed",
+                "7",
+                "--gameweek",
+                "4",
+                "--forecastweeks",
+                "3",
+            ]
+        )
+
+        self.assertEqual(options.input, FIXTURE)
+        self.assertEqual(options.population, 6)
+        self.assertEqual(options.generations, 2)
+        self.assertEqual(options.seed, 7)
+        self.assertEqual(options.gameweek, 4)
+        self.assertEqual(options.forecastweeks, 3)
+
+    def test_parse_args_rejects_invalid_numeric_controls(self):
+        invalid_options = [
+            ["--population", "0"],
+            ["--generations", "0"],
+            ["--gameweek", "0"],
+            ["--forecastweeks", "0"],
+        ]
+
+        for args in invalid_options:
+            with self.subTest(args=args):
+                with self.assertRaises(SystemExit):
+                    with redirect_stderr(io.StringIO()):
+                        ga_module.parse_args(args)
+
+    def test_runner_loads_custom_input_and_writes_inspection_output(self):
+        with redirect_stdout(io.StringIO()):
+            result = ga_module.run(
+                input_path=FIXTURE,
+                population_size=6,
+                generation_limit=1,
+                seed=7,
+            )
+
+        self.assertGreater(result["fittest_score"], 0)
+        self.assertEqual(result["generation_count"], 1)
+        self.assertGreater(len(fpl_module.players), 15)
+        self.assertEqual(fpl_module.players[0]["id"], 201)
+        self.assertTrue((self.data_dir / "playerkeydata").exists())
+
+    def test_runner_seeded_short_run_is_reproducible(self):
+        with redirect_stdout(io.StringIO()):
+            first = ga_module.run(
+                input_path=FIXTURE,
+                population_size=6,
+                generation_limit=2,
+                seed=7,
+            )
+            second = ga_module.run(
+                input_path=FIXTURE,
+                population_size=6,
+                generation_limit=2,
+                seed=7,
+            )
+
+        self.assertEqual(first["fittest_score"], second["fittest_score"])
+        self.assertEqual(first["generation_count"], second["generation_count"])
+
+    def test_runner_horizon_missing_columns_fails_before_population_creation(self):
+        with self.assertRaisesRegex(ValueError, "Missing required fplreview gameweek columns: 9_Pts"):
+            with redirect_stdout(io.StringIO()):
+                ga_module.run(
+                    input_path=FIXTURE,
+                    population_size=6,
+                    generation_limit=1,
+                    seed=7,
+                    gameweek=9,
+                    forecastweeks=1,
+                )
+
+    def test_runner_defaults_do_not_inherit_prior_horizon_overrides(self):
+        with redirect_stdout(io.StringIO()):
+            ga_module.run(
+                input_path=FIXTURE,
+                population_size=6,
+                generation_limit=1,
+                seed=7,
+                gameweek=4,
+                forecastweeks=1,
+            )
+            ga_module.run(
+                input_path=FIXTURE,
+                population_size=6,
+                generation_limit=1,
+                seed=7,
+            )
+
+        self.assertEqual(fpl_module.gameweek, ga_module.DEFAULT_GAMEWEEK)
+        self.assertEqual(fpl_module.forecastweeks, ga_module.DEFAULT_FORECASTWEEKS)
+        self.assertIn("6", fpl_module.players[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

FPLgen can now run the existing production-sized GA path by default while also supporting short, reproducible CLI runs for development and fixture validation. This makes it possible to choose the fplreview export path, population size, generation limit, seed, gameweek, and forecast window without editing source.

The runner now has a callable execution seam, so tests can import and exercise it without accidentally starting a 10,000-player production run. Custom input loading preserves the existing `playerkeydata` inspection output, and the old max-fitness setter now controls the value the loop actually reads.

## Test Plan

- `python3 -m py_compile code/*.py`
- `python3 -m unittest tests.test_ga_runner`
- `python3 -m unittest discover -s tests`
- `python3 code/GA.py --input tests/fixtures/fplreview_golden.csv --population 6 --generations 2 --seed 7`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
