### PR TITLE
docs: mark historical fplkiwi task complete

### DIFF
--- a/docs/brainstorms/2026-06-03-historical-fplkiwi-projection-fixture-requirements.md
+++ b/docs/brainstorms/2026-06-03-historical-fplkiwi-projection-fixture-requirements.md
@@ -1,6 +1,8 @@
 ---
 date: 2026-06-03
 topic: historical-fplkiwi-projection-fixture
+status: completed
+pr: https://github.com/markbarrington/fplgen/pull/7
 ---
 
 # Historical theFPLkiwi Projection Fixture Requirements

--- a/docs/ideation/2026-06-02-repo-improvements-ideation.md
+++ b/docs/ideation/2026-06-02-repo-improvements-ideation.md
@@ -226,12 +226,12 @@ Useful references include the `fpl` package docs, FPLstat's data reference, Oliv
 
 ## Recommendation
 
-Ideas 1, 2, and 3 have shipped: FPLgen now imports a single fplreview.com CSV, has a synthetic golden fixture that proves import, known-squad scoring, and a tiny seeded GA path, and exposes a configurable GA runner for short deterministic runs.
+Ideas 1, 2, 3, and 4 have shipped: FPLgen now imports a single fplreview.com CSV, has a synthetic golden fixture that proves import, known-squad scoring, and a tiny seeded GA path, exposes a configurable GA runner for short deterministic runs, and includes a historical theFPLkiwi projection fixture for realistic projection-row tests.
 
-The next improvement wave should focus on Ideas 4, 5, and 7:
+The next improvement wave should focus on Ideas 5 and 7, with Idea 6 becoming more useful once the realistic state and scoring-rule fixtures are in place:
 
-1. Add a pinned theFPLkiwi projection fixture converted to fplreview-style CSV.
-2. Add a pinned fplcache `bootstrap-static` fixture for realistic player/team mapping.
-3. Cover the scoring and transfer rules that matter most.
+1. Add a pinned fplcache `bootstrap-static` fixture for realistic player/team mapping.
+2. Cover the scoring and transfer rules that matter most.
+3. Add deterministic optimizer health metrics after the realistic fixture base is broader.
 
 Those moves create enough safety to tackle the larger architectural improvements: boundary-first refactor, context object, and validity repair.

--- a/docs/plans/2026-06-03-002-feat-historical-fplkiwi-fixture-plan.md
+++ b/docs/plans/2026-06-03-002-feat-historical-fplkiwi-fixture-plan.md
@@ -4,6 +4,7 @@ type: feat
 status: completed
 date: 2026-06-03
 origin: docs/brainstorms/2026-06-03-historical-fplkiwi-projection-fixture-requirements.md
+pr: https://github.com/markbarrington/fplgen/pull/7
 ---
 
 # feat: Add Historical theFPLkiwi Projection Fixture


### PR DESCRIPTION
## Summary

The historical theFPLkiwi fixture work now has the same completion trail as the earlier shipped tasks. The brainstorm and plan point at PR #7, and the repo-improvements recommendation now treats Idea 4 as shipped instead of leaving it in the next-work queue.

## Verification

- Documentation-only change; no tests run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
