### PR TITLE
refactor: split fplreview projection boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Runtime data is intentionally kept out of Git. Export projections from fplreview
 data/fplreview.csv
 ```
 
-FPLgen uses the configured gameweek columns from the export as the expected score for each player. Those values are loaded directly; FPLgen does not apply additional projection adjustments for strength of schedule, home/away splits, availability, or expected minutes.
+FPLgen imports and normalizes the configured gameweek columns from the export as the expected score for each player. Those values are loaded directly into the optimizer's scoring input; FPLgen does not apply additional projection adjustments for strength of schedule, home/away splits, availability, or expected minutes.
 
-The run writes `data/playerkeydata`, a generated inspection file showing the imported scoring values used by the optimizer.
+The run writes `data/playerkeydata`, a generated inspection file showing the normalized projection values used by the optimizer.
 
 ## Development
 

--- a/code/fpl.py
+++ b/code/fpl.py
@@ -1,8 +1,7 @@
-import json
 import random
-import csv
 
 from paths import data_file
+import projections
 from strength import teamstrength
 
 from operator import itemgetter
@@ -352,163 +351,71 @@ class fpl():
 
     @staticmethod
     def fplreview_gameweek_columns(fieldnames):
-        columns = {}
-        missing = []
-        for week in range(gameweek, gameweek + forecastweeks):
-            candidates = [
-                "%s_Pts" % week,
-                "GW%s_Pts" % week,
-                "GW%s Pts" % week,
-                "%s_PTS" % week,
-                "GW%s_PTS" % week,
-            ]
-            found = None
-            for candidate in candidates:
-                if candidate in fieldnames:
-                    found = candidate
-                    break
-            if found is None:
-                missing.append("%s_Pts" % week)
-            else:
-                columns[week - gameweek + 1] = found
-
-        if missing:
-            raise ValueError(
-                "Missing required fplreview gameweek columns: %s" % ", ".join(missing)
-            )
-
-        return columns
+        return projections.fplreview_gameweek_columns(fieldnames, gameweek, forecastweeks)
 
     @staticmethod
     def fplreview_price(value):
-        price = float(value)
-        if price <= 20:
-            price *= 10
-        return int(round(price))
+        return projections.fplreview_price(value)
 
     @staticmethod
     def fplreview_position(value):
-        position = str(value).strip().lower()
-        positions = {
-            "1": 1,
-            "gk": 1,
-            "gkp": 1,
-            "goalkeeper": 1,
-            "2": 2,
-            "def": 2,
-            "defender": 2,
-            "3": 3,
-            "mid": 3,
-            "midfielder": 3,
-            "4": 4,
-            "fwd": 4,
-            "for": 4,
-            "forward": 4,
-        }
-        if position not in positions:
-            raise ValueError("Unknown fplreview position: %s" % value)
-        return positions[position]
+        return projections.fplreview_position(value)
 
     @staticmethod
     def fplreview_team(value):
         global teamid
 
-        team_name = str(value).strip()
-        for existing_id, existing_name in teamid.items():
-            if existing_name.lower() == team_name.lower():
-                return int(existing_id), existing_name
-
-        next_id = max(int(existing_id) for existing_id in teamid.keys()) + 1
-        teamid[str(next_id)] = team_name
-        return next_id, team_name
+        team, team_name, teamid = projections.resolve_fplreview_team(value, teamid)
+        return team, team_name
 
     @staticmethod
     def map_fplreview_rows(rows, fieldnames):
-        required = ["Pos", "ID", "Name", "BV", "SV", "Team"]
-        missing = [field for field in required if field not in fieldnames]
-        if missing:
-            raise ValueError("Missing required fplreview columns: %s" % ", ".join(missing))
+        global teamid
 
-        point_columns = fpl.fplreview_gameweek_columns(fieldnames)
-        players = []
-        for row in rows:
-            players.append(fpl.map_fplreview_player(row, point_columns))
-        return players
+        normalized, teamid = projections.normalize_fplreview_rows(
+            rows,
+            fieldnames,
+            gameweek,
+            forecastweeks,
+            teamid,
+        )
+        return projections.prepare_scorer_players(normalized, forecastweeks, playertypes)
 
     @staticmethod
     def map_fplreview_player(row, point_columns):
-        player_id = int(row["ID"])
-        element_type = fpl.fplreview_position(row["Pos"])
-        team, team_name = fpl.fplreview_team(row["Team"])
-        now_cost = fpl.fplreview_price(row["BV"])
-        sellprice = fpl.fplreview_price(row["SV"])
+        global teamid
 
-        player = {
-            "id": player_id,
-            "code": player_id,
-            "second_name": row["Name"],
-            "web_name": row["Name"],
-            "team": team,
-            "team_name": team_name,
-            "element_type": element_type,
-            "type_name": playertypes[element_type - 1],
-            "now_cost": now_cost,
-            "sellprice": sellprice,
-            "status": "a",
-            "picked": False,
-            "minutes": 0,
-            "total_points": 0,
-            "tsp": 0,
-            "home": 0,
-            "away": 0,
-            "homegames": 0,
-            "awaygames": 0,
-            "otherteams": ["NONE"] * forecastweeks,
-        }
-
-        lookahead = 0
-        for week, column in point_columns.items():
-            points = float(row[column])
-            player[str(week)] = points
-            lookahead += points
-
-        player["thisweekpoints"] = player["1"]
-        player["lookaheadpoints"] = lookahead
-        player["ppg"] = lookahead / float(forecastweeks)
-        player["total_points"] = lookahead
-        player["tsp"] = lookahead
-
-        return player
+        projection, teamid = projections.normalize_fplreview_player(
+            row,
+            point_columns,
+            forecastweeks,
+            teamid,
+        )
+        return projections.prepare_scorer_player(projection, forecastweeks, playertypes)
 
     @staticmethod
     def load_fplreview_players(filename):
-        with open(filename, "r", encoding="utf-8-sig", newline="") as csvfile:
-            reader = csv.DictReader(csvfile)
-            if reader.fieldnames is None:
-                raise ValueError("fplreview CSV has no header row")
-            rows = list(reader)
-            return fpl.map_fplreview_rows(rows, reader.fieldnames)
+        global teamid
+
+        loaded_players, teamid = projections.load_fplreview_players(
+            filename,
+            gameweek,
+            forecastweeks,
+            teamid,
+            playertypes,
+        )
+        return loaded_players
 
     @staticmethod
     def write_playerkeydata(loaded_players):
-        output = open(data_file('playerkeydata', for_write=True), 'w', encoding='utf-8-sig')
-
-        for player in loaded_players:
-            playerdata = player['second_name']
-            playerdata += "," + str(player['total_points'])
-            playerdata += "," + str(player['minutes'])
-            playerdata += "," + str(player['tsp'])
-            playerdata += "," + str(player['now_cost'])
-            playerdata += "," + player['team_name']
-            playerdata += "," + playertype[str(player['element_type'])]
-            playerdata += "," + str(player['lookaheadpoints'])
-            playerdata += "," + str(player['thisweekpoints'])
-            playerdata += "," + str(player['ppg'])
-            for week in range(1,forecastweeks+1):
-                playerdata += "," + str(player[str(week)])
-            output.write(playerdata + '\n')
-
-        output.close()
+        lines = projections.format_playerkeydata_lines(
+            loaded_players,
+            forecastweeks,
+            playertype,
+        )
+        with open(data_file('playerkeydata', for_write=True), 'w', encoding='utf-8-sig') as output:
+            for line in lines:
+                output.write(line + '\n')
 
     # Read the fplreview export into the player global variable.
     # Output a playerkeydata inspection file.

--- a/code/projections.py
+++ b/code/projections.py
@@ -1,0 +1,227 @@
+import csv
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FplreviewSourceTable:
+    fieldnames: list
+    rows: list
+
+
+@dataclass(frozen=True)
+class FplreviewProjection:
+    player_id: int
+    name: str
+    team: int
+    team_name: str
+    element_type: int
+    now_cost: int
+    sellprice: int
+    weekly_points: dict
+    thisweekpoints: float
+    lookaheadpoints: float
+    ppg: float
+    total_points: float
+    tsp: float
+
+
+def read_fplreview_csv(filename):
+    with open(filename, "r", encoding="utf-8-sig", newline="") as csvfile:
+        reader = csv.DictReader(csvfile)
+        if reader.fieldnames is None:
+            raise ValueError("fplreview CSV has no header row")
+        return FplreviewSourceTable(fieldnames=reader.fieldnames, rows=list(reader))
+
+
+def fplreview_gameweek_columns(fieldnames, gameweek, forecastweeks):
+    columns = {}
+    missing = []
+    for week in range(gameweek, gameweek + forecastweeks):
+        candidates = [
+            "%s_Pts" % week,
+            "GW%s_Pts" % week,
+            "GW%s Pts" % week,
+            "%s_PTS" % week,
+            "GW%s_PTS" % week,
+        ]
+        found = None
+        for candidate in candidates:
+            if candidate in fieldnames:
+                found = candidate
+                break
+        if found is None:
+            missing.append("%s_Pts" % week)
+        else:
+            columns[week - gameweek + 1] = found
+
+    if missing:
+        raise ValueError(
+            "Missing required fplreview gameweek columns: %s" % ", ".join(missing)
+        )
+
+    return columns
+
+
+def fplreview_price(value):
+    price = float(value)
+    if price <= 20:
+        price *= 10
+    return int(round(price))
+
+
+def fplreview_position(value):
+    position = str(value).strip().lower()
+    positions = {
+        "1": 1,
+        "gk": 1,
+        "gkp": 1,
+        "goalkeeper": 1,
+        "2": 2,
+        "def": 2,
+        "defender": 2,
+        "3": 3,
+        "mid": 3,
+        "midfielder": 3,
+        "4": 4,
+        "fwd": 4,
+        "for": 4,
+        "forward": 4,
+    }
+    if position not in positions:
+        raise ValueError("Unknown fplreview position: %s" % value)
+    return positions[position]
+
+
+def resolve_fplreview_team(value, team_map):
+    updated_team_map = {str(team_id): team_name for team_id, team_name in team_map.items()}
+    team_name = str(value).strip()
+    for existing_id, existing_name in updated_team_map.items():
+        if existing_name.lower() == team_name.lower():
+            return int(existing_id), existing_name, updated_team_map
+
+    next_id = max(int(existing_id) for existing_id in updated_team_map.keys()) + 1
+    updated_team_map[str(next_id)] = team_name
+    return next_id, team_name, updated_team_map
+
+
+def normalize_fplreview_rows(rows, fieldnames, gameweek, forecastweeks, team_map):
+    required = ["Pos", "ID", "Name", "BV", "SV", "Team"]
+    missing = [field for field in required if field not in fieldnames]
+    if missing:
+        raise ValueError("Missing required fplreview columns: %s" % ", ".join(missing))
+
+    point_columns = fplreview_gameweek_columns(fieldnames, gameweek, forecastweeks)
+    working_team_map = {str(team_id): team_name for team_id, team_name in team_map.items()}
+    projections = []
+    for row in rows:
+        projection, working_team_map = normalize_fplreview_player(
+            row,
+            point_columns,
+            forecastweeks,
+            working_team_map,
+        )
+        projections.append(projection)
+    return projections, working_team_map
+
+
+def normalize_fplreview_player(row, point_columns, forecastweeks, team_map):
+    player_id = int(row["ID"])
+    element_type = fplreview_position(row["Pos"])
+    team, team_name, updated_team_map = resolve_fplreview_team(row["Team"], team_map)
+    now_cost = fplreview_price(row["BV"])
+    sellprice = fplreview_price(row["SV"])
+
+    weekly_points = {}
+    lookahead = 0
+    for week, column in point_columns.items():
+        points = float(row[column])
+        weekly_points[week] = points
+        lookahead += points
+
+    projection = FplreviewProjection(
+        player_id=player_id,
+        name=row["Name"],
+        team=team,
+        team_name=team_name,
+        element_type=element_type,
+        now_cost=now_cost,
+        sellprice=sellprice,
+        weekly_points=weekly_points,
+        thisweekpoints=weekly_points[1],
+        lookaheadpoints=lookahead,
+        ppg=lookahead / float(forecastweeks),
+        total_points=lookahead,
+        tsp=lookahead,
+    )
+    return projection, updated_team_map
+
+
+def prepare_scorer_players(projections, forecastweeks, playertypes):
+    return [
+        prepare_scorer_player(projection, forecastweeks, playertypes)
+        for projection in projections
+    ]
+
+
+def prepare_scorer_player(projection, forecastweeks, playertypes):
+    player = {
+        "id": projection.player_id,
+        "code": projection.player_id,
+        "second_name": projection.name,
+        "web_name": projection.name,
+        "team": projection.team,
+        "team_name": projection.team_name,
+        "element_type": projection.element_type,
+        "type_name": playertypes[projection.element_type - 1],
+        "now_cost": projection.now_cost,
+        "sellprice": projection.sellprice,
+        "status": "a",
+        "picked": False,
+        "minutes": 0,
+        "total_points": projection.total_points,
+        "tsp": projection.tsp,
+        "home": 0,
+        "away": 0,
+        "homegames": 0,
+        "awaygames": 0,
+        "otherteams": ["NONE"] * forecastweeks,
+        "thisweekpoints": projection.thisweekpoints,
+        "lookaheadpoints": projection.lookaheadpoints,
+        "ppg": projection.ppg,
+    }
+
+    for week, points in projection.weekly_points.items():
+        player[str(week)] = points
+
+    return player
+
+
+def load_fplreview_players(filename, gameweek, forecastweeks, team_map, playertypes):
+    source = read_fplreview_csv(filename)
+    projections, updated_team_map = normalize_fplreview_rows(
+        source.rows,
+        source.fieldnames,
+        gameweek,
+        forecastweeks,
+        team_map,
+    )
+    return prepare_scorer_players(projections, forecastweeks, playertypes), updated_team_map
+
+
+def format_playerkeydata_lines(loaded_players, forecastweeks, playertype):
+    lines = []
+    for player in loaded_players:
+        playerdata = player["second_name"]
+        playerdata += "," + str(player["total_points"])
+        playerdata += "," + str(player["minutes"])
+        playerdata += "," + str(player["tsp"])
+        playerdata += "," + str(player["now_cost"])
+        playerdata += "," + player["team_name"]
+        playerdata += "," + playertype[str(player["element_type"])]
+        playerdata += "," + str(player["lookaheadpoints"])
+        playerdata += "," + str(player["thisweekpoints"])
+        playerdata += "," + str(player["ppg"])
+        for week in range(1, forecastweeks + 1):
+            playerdata += "," + str(player[str(week)])
+        lines.append(playerdata)
+    return lines

--- a/docs/brainstorms/2026-06-05-import-projection-scoring-boundaries-requirements.md
+++ b/docs/brainstorms/2026-06-05-import-projection-scoring-boundaries-requirements.md
@@ -1,0 +1,132 @@
+---
+date: 2026-06-05
+topic: import-projection-scoring-boundaries
+---
+
+# Requirements: Import, Projection, and Scoring Boundaries
+
+## Summary
+
+FPLgen will split the current fplreview data path into explicit import, projection normalization, scoring-input, and inspection-output boundaries. The first version should preserve current optimizer behavior while making the data path easier to test, reason about, and extend toward future run-state and projection-model work.
+
+---
+
+## Problem Frame
+
+FPLgen now has a practical fplreview CSV import path, a configurable runner, historical projection fixtures, and existing-squad scenarios. That restored the product workflow, but much of the data path still lives inside `code/fpl.py` as one blended responsibility.
+
+The current fplreview path validates CSV fields, maps rows into scorer-ready player dictionaries, assigns global player state, derives projection summary fields, and writes `playerkeydata` for inspection. Scoring then reads the same mutable player shape and shared module state. This makes each change harder to reason about because import behavior, projection semantics, scorer expectations, and debug output are coupled.
+
+The next improvement should introduce clearer boundaries without turning into a full rewrite. The useful move is to make each stage visible and testable, keep the current optimizer contract intact, and leave a cleaner stepping stone toward a future `RunConfig` or `FplContext`.
+
+---
+
+## Key Decisions
+
+- **Boundary-first, behavior-preserving refactor.** The refactor should make responsibilities explicit without changing squad recommendations, scoring semantics, transfer behavior, chip behavior, or runner defaults.
+- **Small cleanup changes are allowed.** If the touched path exposes low-risk awkward coupling or duplicated validation, the implementation may clean it up as part of the boundary split.
+- **Current player shape remains the scorer contract for v1.** Planning may introduce intermediate structures, but the GA and scoring path should not be forced to consume a new domain model in this pass.
+- **Projection values stay final EV inputs.** fplreview gameweek points remain the expected scores used by scoring, with no new local availability, minutes, strength-of-schedule, or home-away adjustment.
+- **This prepares for `FplContext`; it does not require it.** The work should reduce future context-migration risk, but full ownership of players, budget, gameweek, chip flags, and scoring constants is deferred.
+
+---
+
+## Requirements
+
+**Import and validation boundary**
+
+- R1. The fplreview source import must be distinguishable from projection normalization, scoring preparation, global state assignment, and inspection output.
+- R2. Source validation must still fail fast when required fplreview identity, price, team, position, or configured gameweek point fields are missing.
+- R3. Source import must remain path-driven so the runner, tests, and fixture utilities can load explicit CSV files.
+- R4. Import validation errors should identify source-data problems before optimizer population creation.
+
+**Projection normalization boundary**
+
+- R5. Projection normalization must convert fplreview rows into normalized player/projection data that preserves FPL ID, display name, team, position, buy value, sell value, and each configured gameweek EV.
+- R6. Normalization must continue to derive current summary values needed by the existing scorer and output path, including this-week points, lookahead points, average projected points, and total projection fields.
+- R7. fplreview gameweek EVs must flow into scoring without additional local projection adjustment.
+- R8. Normalization must preserve team and position mapping behavior currently covered by importer tests.
+
+**Scoring input boundary**
+
+- R9. The scorer-facing input must retain the fields and semantics required by current squad generation, validation, transfer affordability, chips, and weekly scoring.
+- R10. Existing GW1 fresh-squad behavior and non-GW1 scenario behavior must remain unchanged.
+- R11. Scenario validation must still resolve current-squad IDs against the loaded player pool before optimization.
+- R12. Scoring behavior must remain testable independently from source CSV parsing wherever existing fixtures make that practical.
+
+**Inspection output boundary**
+
+- R13. `playerkeydata` should remain available as an inspection artifact after player data is loaded.
+- R14. Inspection output should be downstream of normalized projection data rather than part of source import itself.
+- R15. The inspection output must continue to reflect the configured forecast horizon and loaded projection values.
+
+**Regression and compatibility**
+
+- R16. Existing fplreview import, golden fixture, historical projection fixture, scenario, and GA runner tests must continue to pass.
+- R17. New or updated tests must prove that boundary extraction preserves normalized player values and scorer-visible behavior for representative fixtures.
+- R18. Any small cleanup change included in this work must be covered by characterization or regression tests when it could affect optimizer behavior.
+- R19. Documentation should continue to describe the same user-facing run workflow unless the implementation exposes a clearer way to explain the data path.
+
+---
+
+## Key Flow
+
+- F1. Load projections for a run
+  - **Trigger:** A user or test runs FPLgen with a fplreview-style CSV path.
+  - **Steps:** FPLgen validates the source CSV, normalizes projection data, prepares scorer-compatible player data, publishes it to the current run path, and writes inspection output.
+  - **Outcome:** The optimizer sees the same effective player pool and projection scores as before, but each stage can be tested and evolved separately.
+  - **Covered by:** R1-R17
+
+```mermaid
+flowchart TB
+  A["fplreview CSV source"] --> B["Source import and validation"]
+  B --> C["Projection normalization"]
+  C --> D["Scorer-compatible player data"]
+  D --> E["Current GA and scoring path"]
+  C --> F["Inspection output"]
+```
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1-R4.** Given a fplreview fixture is missing a required gameweek point column, when FPLgen loads projections, then the run fails before scenario validation or population creation.
+- AE2. **Covers R5-R8.** Given a valid fplreview fixture row, when projection normalization runs, then the normalized data preserves identity, position, team, buy value, sell value, weekly EVs, and derived projection summary values.
+- AE3. **Covers R7, R9, R16.** Given the golden fplreview fixture, when the boundary split is applied, then known-squad scoring produces the same behavior as the pre-refactor path.
+- AE4. **Covers R10-R12.** Given a non-GW1 scenario, when the runner loads projections and validates the scenario, then the current squad resolves against the loaded player pool and starts optimization with the same scenario semantics.
+- AE5. **Covers R13-R15.** Given a configured forecast horizon, when player data is loaded, then `playerkeydata` is written from normalized projection values for the same horizon.
+- AE6. **Covers R18.** Given a cleanup change touches a scorer-visible value, when tests run, then a focused regression test proves the value or behavior did not unintentionally change.
+
+---
+
+## Scope Boundaries
+
+- New projection models, EV blending, uncertainty distributions, expected-minutes adjustments, and source-disagreement analysis are deferred.
+- Full `RunConfig` or `FplContext` migration is deferred.
+- Full removal of global state from scoring, chips, transfers, and GA orchestration is deferred.
+- Broad scoring-rule edge-case coverage is deferred except where needed to prove boundary behavior.
+- Exact solver benchmarking and optimizer-quality metrics are deferred.
+- Live FPL API integration and fplcache state ingestion are out of scope for this item.
+- Replacing the current player dictionary contract across the GA and scorer is out of scope for v1.
+
+---
+
+## Dependencies and Assumptions
+
+- fplreview-style CSV remains the current runtime projection source.
+- Existing fixtures are sufficient to prove boundary-preserving behavior for the first pass.
+- Current scorer and GA code can continue consuming the existing player shape while the upstream data path becomes clearer.
+- `playerkeydata` is still useful as a local inspection artifact, even if its generation moves behind a clearer output boundary.
+- Some legacy fixture-based projection code may remain in place if removing it would broaden the refactor beyond the staged goal.
+
+---
+
+## Sources
+
+- Ideation seed: `docs/ideation/2026-06-02-repo-improvements-ideation.md`
+- fplreview import requirements: `docs/brainstorms/2026-06-02-fplreview-import-requirements.md`
+- Existing-squad scenario plan: `docs/plans/2026-06-03-003-feat-existing-squad-scenario-plan.md`
+- Current runner: `code/GA.py`
+- Current import, projection, inspection, and scoring code: `code/fpl.py`
+- Scenario validation: `code/scenario.py`
+- Existing regression fixtures and tests: `tests/fixtures/`, `tests/test_fplreview_import.py`, `tests/test_fplreview_golden.py`, `tests/test_fplkiwi_historical_fixture.py`, `tests/test_existing_squad_optimizer.py`, `tests/test_ga_runner.py`

--- a/docs/plans/2026-06-05-001-refactor-import-projection-boundaries-plan.md
+++ b/docs/plans/2026-06-05-001-refactor-import-projection-boundaries-plan.md
@@ -1,0 +1,261 @@
+---
+title: "refactor: Split import projection and scoring boundaries"
+type: refactor
+status: completed
+date: 2026-06-05
+origin: docs/brainstorms/2026-06-05-import-projection-scoring-boundaries-requirements.md
+---
+
+# refactor: Split Import Projection and Scoring Boundaries
+
+## Summary
+
+Refactor FPLgen's fplreview data path so source import, projection normalization, scorer-compatible player preparation, global run-state publication, and inspection output are clear stages. Preserve current optimizer behavior while creating a cleaner stepping stone toward future `RunConfig`, `FplContext`, and projection-source work.
+
+---
+
+## Problem Frame
+
+The current fplreview path in `code/fpl.py` blends CSV validation, row mapping, projection summary derivation, global `players` assignment, and `playerkeydata` output. Scoring and scenario validation then depend on the resulting mutable player dictionaries and module globals.
+
+The origin requirements call for a boundary-first, behavior-preserving refactor. This plan keeps the current player dictionary contract for the GA and scoring path, adds characterization around the handoff points, and extracts enough structure that future work can replace or extend stages without guessing which behavior belongs to import, projection, scoring, or inspection.
+
+---
+
+## Requirements
+
+**Boundary behavior**
+
+- R1. fplreview source reading and validation are separable from projection normalization, scorer preparation, global state publication, and inspection output. Origin: R1-R2.
+- R2. Normalization preserves FPL ID, display name, team, position, buy value, sell value, weekly EVs, and derived projection summaries. Origin: R5-R8.
+- R3. Scorer-compatible player dictionaries retain the current fields and semantics needed by squad generation, transfer affordability, scenario validation, chips, and scoring. Origin: R9-R12.
+- R4. `playerkeydata` remains available after loading data and is generated from normalized projection values. Origin: R13-R15.
+
+**Compatibility**
+
+- R5. Existing GW1, non-GW1 scenario, known-squad scoring, historical fixture, and runner behaviors remain unchanged. Origin: R10-R17.
+- R6. Source import remains path-driven so the runner, tests, and fixture utilities can load explicit fplreview CSV files. Origin: R3.
+- R7. Import and validation failures still happen before scenario validation or optimizer population creation. Origin: R4, AE1.
+- R8. fplreview EVs continue to flow into scoring without local projection adjustment. Origin: R7, AE3.
+- R9. Small cleanup changes are limited to the touched data path and must be covered when they can affect scorer-visible behavior. Origin: R18.
+
+**Documentation**
+
+- R10. README changes are limited to clarifying the internal data path if the refactor makes the current wording stale. Origin: R19.
+
+---
+
+## Key Technical Decisions
+
+- **Keep the scorer contract stable:** The GA, `Population`, `Individual`, scenario validation, and scoring should continue consuming player dictionaries in the current shape. This confines risk while still making the upstream data path clearer.
+- **Introduce a fplreview-specific boundary module before migrating callers:** A focused module for the current fplreview CSV path gives tests a place to target without requiring a full `FplContext`. This is not a provider abstraction, registry, or generic projection-source framework.
+- **Keep compatibility wrappers during the transition:** Existing public helpers such as the loader path used by tests and the runner should remain available, delegating to the new boundary stages where practical.
+- **Characterization-first execution posture:** This is a legacy, global-state-heavy path. Add or tighten tests around current behavior before moving responsibilities.
+- **Localize team-map mutation:** Normalization should avoid hidden global `teamid` mutation where practical by working from an explicit or copied team map. Compatibility wrappers can apply team-map additions when legacy behavior requires them.
+- **Do not remove legacy fixture projection code in this pass:** The old fixture-based projection functions can stay unless implementation reveals a tiny, obviously safe cleanup. Removing them would broaden the refactor beyond the origin scope.
+
+---
+
+## High-Level Technical Design
+
+The planned shape is a staged pipeline. The last stage still publishes the existing player dictionaries into the current run state so downstream optimizer behavior stays stable.
+
+```mermaid
+flowchart TB
+  A["fplreview CSV path"] --> B["Source import and validation"]
+  B --> C["Projection normalization"]
+  C --> D["Scorer-compatible player preparation"]
+  D --> E["Current run-state publication"]
+  E --> F["Scenario validation and GA scoring"]
+  C --> G["Inspection output formatting"]
+  G --> H["playerkeydata"]
+```
+
+The boundary module should own stages B through D and G for the fplreview CSV path only. `code/fpl.py` may keep compatibility-facing wrappers and the current scoring functions while the implementation migrates internals behind those wrappers.
+
+Directional boundary contract:
+
+- Source import returns CSV rows plus field names from an explicit path.
+- Projection normalization returns fplreview projection records with identity, team, position, prices, weekly EVs, and derived summary values.
+- Scorer preparation converts normalized projection records into the current player dictionary shape.
+- Inspection formatting produces `playerkeydata` lines from normalized projection values, or from prepared players only when they preserve the same projection values.
+
+---
+
+## Implementation Units
+
+### U1. Characterize Current Data Handoff Behavior
+
+- **Goal:** Add focused tests that lock down the current values crossing from fplreview import into scorer-visible player data and inspection output.
+- **Requirements:** R1-R9
+- **Dependencies:** None
+- **Files:**
+  - `tests/test_fplreview_import.py`
+  - `tests/test_fplreview_golden.py`
+  - `tests/test_ga_runner.py`
+- **Approach:** Expand characterization around the existing import surface before moving code. Prefer assertions on observable values and failure order over assertions on internal helper names.
+- **Execution note:** Start here so later extraction work has a behavior harness before responsibilities move.
+- **Patterns to follow:** Existing fixture-based assertions in `tests/test_fplreview_import.py`; known-squad scoring in `tests/test_fplreview_golden.py`; pre-population failure checks in `tests/test_ga_runner.py`.
+- **Test scenarios:**
+  - Covers AE1. A missing configured gameweek column still fails before scenario validation or `Population` is created.
+  - Covers AE2. A representative fplreview row maps into scorer-visible values for identity, team, position, prices, weekly EVs, lookahead points, this-week points, average projection, and total projection fields.
+  - Covers AE3. The golden known-squad score remains unchanged.
+  - Covers AE5. `playerkeydata` contains projection values for the configured forecast horizon.
+- **Verification:** The added or tightened characterization tests fail against intentional changes to scorer-visible projection values or failure ordering.
+
+### U2. Extract Source Import and Projection Normalization
+
+- **Goal:** Separate CSV source reading, required-column validation, and projection normalization into a boundary that can be tested without invoking global run-state assignment or inspection output.
+- **Requirements:** R1, R2, R6-R8
+- **Dependencies:** U1
+- **Files:**
+  - `code/fpl.py`
+  - `code/projections.py` (new)
+  - `tests/test_fplreview_import.py`
+  - `tests/test_fplkiwi_historical_fixture.py`
+- **Approach:** Move fplreview-specific source and normalization responsibilities behind a focused module while preserving current helper behavior through compatibility wrappers. Keep the normalized data sufficient to derive the existing player fields without introducing new projection math, provider abstractions, or source registries.
+- **Technical design:** Directional only: source import returns rows and fieldnames; normalization returns fplreview projection records; scorer preparation turns those records into current player dictionaries. Team mapping should receive an explicit or copied team map and surface any additions so compatibility wrappers can apply legacy global mutations intentionally.
+- **Patterns to follow:** Current validation behavior in `fplreview_gameweek_columns`; price, position, and team mapping behavior currently asserted by importer and historical-fixture tests.
+- **Test scenarios:**
+  - Covers AE1. Missing required source columns and missing configured gameweek columns raise the same class of fast validation errors.
+  - Covers AE2. Normalization preserves values from both the minimal fplreview fixture and the historical theFPLkiwi-derived fixture.
+  - A blank or malformed CSV header still fails before scorer-compatible player data is produced.
+  - Team names not already present in the team map continue to receive stable IDs within a load.
+  - Repeated normalization tests with unknown teams do not leak unexpected `teamid` mutations or renumber teams across tests.
+- **Verification:** Existing direct calls to the fplreview loader still work, and new normalization-level tests can run without writing `playerkeydata`.
+
+### U3. Define Scorer-Compatible Player Preparation
+
+- **Goal:** Make the conversion from normalized projections to existing scorer-compatible player dictionaries explicit.
+- **Requirements:** R2, R3, R5, R8, R9
+- **Dependencies:** U2
+- **Files:**
+  - `code/fpl.py`
+  - `code/projections.py` (new)
+  - `tests/test_fplreview_import.py`
+  - `tests/test_fplreview_golden.py`
+  - `tests/test_existing_squad_optimizer.py`
+- **Approach:** Treat the current player dictionary shape as the v1 scoring adapter. Keep fields used by generation, transfers, scenarios, chips, and scoring intact, and document in tests which values are scorer-facing rather than source-facing.
+- **Patterns to follow:** Existing player dictionary keys produced by `map_fplreview_player`; scenario ID resolution in `code/scenario.py`; known-squad helpers in `tests/test_fplreview_golden.py`.
+- **Test scenarios:**
+  - Covers AE2. Prepared players expose the current scorer fields for IDs, costs, status, team, position, and weekly projection keys.
+  - Covers AE3. Known-squad scoring against the golden fixture remains `423.6`.
+  - Covers AE4. A non-GW1 scenario resolves IDs against prepared players and scores with the existing scenario bank semantics.
+  - A fresh GW1 population still generates varied squads from the prepared global player pool.
+- **Verification:** GA and scoring tests pass without requiring downstream classes to learn a new player model.
+
+### U4. Split Inspection Output From Load Side Effects
+
+- **Goal:** Make `playerkeydata` generation consume normalized projection data as an output stage rather than being embedded in source import.
+- **Requirements:** R1, R4, R9
+- **Dependencies:** U2, U3
+- **Files:**
+  - `code/fpl.py`
+  - `code/projections.py` (new)
+  - `tests/test_fplreview_import.py`
+  - `tests/test_ga_runner.py`
+- **Approach:** Keep `playerkeydata` writing in the existing runtime flow, but route it through an inspection-output boundary based on normalized projection values. Prepared player dictionaries may be used only when they preserve the same projection values. Preserve the file content expectations already useful to tests while making it possible to load and normalize projections without writing files.
+- **Patterns to follow:** Existing `write_playerkeydata` output format; temporary `data_file` patching in runner and import tests.
+- **Test scenarios:**
+  - Covers AE5. Loading player data through the compatibility runtime path writes `playerkeydata`.
+  - Direct normalization or scorer-preparation tests can run without creating `playerkeydata`.
+  - The written inspection output reflects the active forecast horizon after `--forecastweeks` changes.
+  - Missing output directory handling continues to use the existing `data_file(..., for_write=True)` behavior.
+- **Verification:** Runtime tests still observe `playerkeydata`, while lower-level boundary tests do not need filesystem output.
+
+### U5. Rewire Runner and Scenario Integration Through the Boundary
+
+- **Goal:** Ensure existing fplreview CSV loading call sites and loaded-player consumers use the boundary-backed path consistently.
+- **Requirements:** R5-R7
+- **Dependencies:** U2, U3, U4
+- **Files:**
+  - `code/GA.py`
+  - `code/generate_scenario.py`
+  - `code/fpl.py`
+  - `tests/test_ga_runner.py`
+  - `tests/test_generate_scenario.py`
+  - `tests/test_existing_squad_optimizer.py`
+- **Approach:** Preserve the existing runner order: apply runtime options, load players, require or validate scenario for non-GW1 runs, then create the population. Keep scenario validation against the loaded player pool, but do not refactor `code/scenario.py` internals unless implementation proves it is necessary to preserve behavior.
+- **Patterns to follow:** Current `GA.run()` ordering; scenario generator loading pattern; pre-population failure assertions in `tests/test_ga_runner.py`.
+- **Test scenarios:**
+  - Covers AE1. A projection import failure still happens before scenario validation or population creation.
+  - Covers AE4. A valid non-GW1 scenario still prints context and starts from the current squad.
+  - A scenario gameweek mismatch still fails before population creation after projections are loaded.
+  - Scenario generator output still validates against players loaded through the boundary-backed path.
+- **Verification:** Existing runner and scenario test suite passes with no user-facing CLI changes.
+
+### U6. Documentation and Cleanup Pass
+
+- **Goal:** Update documentation only where needed and keep cleanup limited to the data path touched by the refactor.
+- **Requirements:** R9, R10
+- **Dependencies:** U1-U5
+- **Files:**
+  - `README.md`
+  - `code/fpl.py`
+  - `code/projections.py` (new)
+  - `tests/test_fplreview_import.py`
+- **Approach:** Revise docs only if the refactor changes how to describe the data path or `playerkeydata`. Remove duplicated helper logic only when tests cover the behavior and the cleanup does not broaden into scoring, chip, or transfer refactors.
+- **Patterns to follow:** Current README's concise data-file explanation; existing test-first style for data-path changes.
+- **Test scenarios:**
+  - Covers AE6. Any cleanup touching scorer-visible fields has a focused regression assertion.
+  - Test expectation for README-only edits: none -- documentation is verified by review.
+- **Verification:** The final diff shows no broad scoring-rule, chip, transfer, solver, or context-object rewrite.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- Full `RunConfig` or `FplContext` migration.
+- Alternate projection sources beyond fplreview-style CSV.
+- Projection ensembles, EV blending, uncertainty distributions, or source-disagreement reporting.
+- Broad scoring-rule edge-case coverage unrelated to the boundary split.
+- Optimizer-quality metrics, exact solver benchmarking, or invalid-individual repair.
+
+### Out of Scope
+
+- Changing squad recommendations as an intended outcome.
+- Replacing the player dictionary contract across GA and scoring in v1.
+- Live FPL API integration.
+- fplcache official-state ingestion.
+- Removing legacy fixture-based projection code unless implementation reveals a tiny, well-covered cleanup.
+
+---
+
+## System-Wide Impact
+
+- **Runtime behavior:** The CLI and normal run workflow should stay unchanged.
+- **Testing:** Data-path tests should become more targeted because import, normalization, scorer preparation, and inspection output can be exercised separately.
+- **Architecture:** The refactor reduces coupling around `code/fpl.py` but leaves scoring globals and the player dictionary contract in place for compatibility.
+- **Future work:** The boundary gives later plans a clearer insertion point for `RunConfig`, `FplContext`, and alternative projection inputs.
+
+---
+
+## Risks and Dependencies
+
+- **Hidden player-field dependencies:** Scoring, generation, transfers, and scenarios may depend on implicit dictionary keys. Mitigation: characterize scorer-compatible fields before extraction and keep the v1 adapter stable.
+- **Global state leakage:** `gameweek`, `forecastweeks`, `players`, `fixtures`, and `teamid` remain mutable globals. Mitigation: keep tests restoring state and avoid claiming global-state removal in this plan.
+- **Behavior drift through cleanup:** Small cleanup changes can alter scoring if they touch derived values. Mitigation: require focused regression coverage for any scorer-visible cleanup.
+- **Over-expansion into architecture rewrite:** The new boundary can invite a full context migration. Mitigation: defer `FplContext` and keep downstream consumers unchanged.
+
+---
+
+## Documentation Notes
+
+- README should continue to present the same run commands unless implementation changes wording around data loading.
+- If the boundary module makes the internal data path easier to explain, add a short note that fplreview values are imported, normalized, and written to `playerkeydata` as inspection output.
+- Do not document new public CLI or config behavior because this plan should not add any.
+
+---
+
+## Sources and Research
+
+- Origin requirements: `docs/brainstorms/2026-06-05-import-projection-scoring-boundaries-requirements.md`
+- Prior fplreview import requirements: `docs/brainstorms/2026-06-02-fplreview-import-requirements.md`
+- Existing-squad scenario plan: `docs/plans/2026-06-03-003-feat-existing-squad-scenario-plan.md`
+- Repo improvement ideation: `docs/ideation/2026-06-02-repo-improvements-ideation.md`
+- Current data path and scoring: `code/fpl.py`
+- Current runner: `code/GA.py`
+- Scenario validation: `code/scenario.py`
+- Existing tests: `tests/test_fplreview_import.py`, `tests/test_fplreview_golden.py`, `tests/test_fplkiwi_historical_fixture.py`, `tests/test_existing_squad_optimizer.py`, `tests/test_ga_runner.py`, `tests/test_generate_scenario.py`

--- a/tests/test_fplreview_import.py
+++ b/tests/test_fplreview_import.py
@@ -14,6 +14,12 @@ if str(CODE_DIR) not in sys.path:
 
 fpl_module = importlib.import_module("fpl")
 from fpl import fpl
+from projections import (
+    format_playerkeydata_lines,
+    normalize_fplreview_rows,
+    prepare_scorer_players,
+    read_fplreview_csv,
+)
 
 
 class FplReviewImportTests(unittest.TestCase):
@@ -21,6 +27,7 @@ class FplReviewImportTests(unittest.TestCase):
         self.tempdir = tempfile.TemporaryDirectory()
         self.data_dir = Path(self.tempdir.name)
         self.original_data_file = fpl_module.data_file
+        self.original_teamid = dict(fpl_module.teamid)
 
         def temp_data_file(filename, for_write=False):
             if for_write:
@@ -31,6 +38,7 @@ class FplReviewImportTests(unittest.TestCase):
 
     def tearDown(self):
         fpl_module.data_file = self.original_data_file
+        fpl_module.teamid = self.original_teamid
         self.tempdir.cleanup()
         fpl_module.players = []
         fpl_module.fixtures = []
@@ -60,6 +68,119 @@ class FplReviewImportTests(unittest.TestCase):
         self.assertEqual(midfielder["thisweekpoints"], 6.2)
         self.assertAlmostEqual(midfielder["lookaheadpoints"], 38.1)
         self.assertAlmostEqual(midfielder["ppg"], 38.1 / fpl_module.forecastweeks)
+
+    def test_normalization_preserves_projection_values_without_writing_inspection_output(self):
+        source = read_fplreview_csv(FIXTURE)
+
+        normalized, updated_teamid = normalize_fplreview_rows(
+            source.rows,
+            source.fieldnames,
+            fpl_module.gameweek,
+            fpl_module.forecastweeks,
+            fpl_module.teamid,
+        )
+        players = prepare_scorer_players(
+            normalized,
+            fpl_module.forecastweeks,
+            fpl_module.playertypes,
+        )
+        midfielder = players[2]
+
+        self.assertFalse((self.data_dir / "playerkeydata").exists())
+        self.assertEqual(updated_teamid, fpl_module.teamid)
+        self.assertEqual(normalized[2].player_id, 103)
+        self.assertEqual(normalized[2].team_name, "Man City")
+        self.assertEqual(normalized[2].element_type, 3)
+        self.assertEqual(normalized[2].now_cost, 80)
+        self.assertEqual(normalized[2].sellprice, 79)
+        self.assertEqual(normalized[2].weekly_points[1], 6.2)
+        self.assertEqual(midfielder["1"], 6.2)
+        self.assertEqual(midfielder["thisweekpoints"], 6.2)
+        self.assertAlmostEqual(midfielder["lookaheadpoints"], 38.1)
+
+    def test_normalization_with_new_teams_keeps_stable_local_team_map(self):
+        rows = [
+            {
+                "Pos": "MID",
+                "ID": "999",
+                "Name": "New Team Midfielder",
+                "BV": "5.5",
+                "SV": "5.4",
+                "Team": "New Club",
+                "3_Pts": "1.1",
+                "4_Pts": "1.2",
+                "5_Pts": "1.3",
+                "6_Pts": "1.4",
+                "7_Pts": "1.5",
+                "8_Pts": "1.6",
+            },
+            {
+                "Pos": "DEF",
+                "ID": "1000",
+                "Name": "New Team Defender",
+                "BV": "4.5",
+                "SV": "4.4",
+                "Team": "New Club",
+                "3_Pts": "2.1",
+                "4_Pts": "2.2",
+                "5_Pts": "2.3",
+                "6_Pts": "2.4",
+                "7_Pts": "2.5",
+                "8_Pts": "2.6",
+            },
+            {
+                "Pos": "FWD",
+                "ID": "1001",
+                "Name": "Other New Forward",
+                "BV": "6.5",
+                "SV": "6.4",
+                "Team": "Other New Club",
+                "3_Pts": "3.1",
+                "4_Pts": "3.2",
+                "5_Pts": "3.3",
+                "6_Pts": "3.4",
+                "7_Pts": "3.5",
+                "8_Pts": "3.6",
+            }
+        ]
+        fieldnames = list(rows[0].keys())
+
+        first, first_teamid = normalize_fplreview_rows(
+            rows,
+            fieldnames,
+            fpl_module.gameweek,
+            fpl_module.forecastweeks,
+            fpl_module.teamid,
+        )
+        second, second_teamid = normalize_fplreview_rows(
+            rows,
+            fieldnames,
+            fpl_module.gameweek,
+            fpl_module.forecastweeks,
+            fpl_module.teamid,
+        )
+
+        self.assertNotIn("New Club", fpl_module.teamid.values())
+        self.assertNotIn("Other New Club", fpl_module.teamid.values())
+        self.assertEqual(first[0].team, first[1].team)
+        self.assertNotEqual(first[0].team, first[2].team)
+        self.assertEqual(
+            [projection.team for projection in first],
+            [projection.team for projection in second],
+        )
+        self.assertEqual(first_teamid, second_teamid)
+        self.assertIn("New Club", first_teamid.values())
+        self.assertIn("Other New Club", first_teamid.values())
+
+    def test_source_import_rejects_csv_without_header_row(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            source_path = Path(tempdir) / "empty.csv"
+            source_path.write_text("", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "fplreview CSV has no header row"):
+                read_fplreview_csv(source_path)
+
+            self.assertFalse((self.data_dir / "playerkeydata").exists())
 
     def test_missing_required_column_fails_fast(self):
         with open(FIXTURE, newline="", encoding="utf-8") as fixture:
@@ -92,6 +213,49 @@ class FplReviewImportTests(unittest.TestCase):
         output = playerkeydata.read_text(encoding="utf-8-sig")
         self.assertIn("Beta Defender", output)
         self.assertIn(",5.0,4.8,4.7,4.9,5.1,5.2", output)
+
+    def test_inspection_output_formats_loaded_projection_values(self):
+        players = fpl.load_fplreview_players(FIXTURE)
+
+        lines = format_playerkeydata_lines(
+            players,
+            fpl_module.forecastweeks,
+            fpl_module.playertype,
+        )
+
+        self.assertEqual(
+            lines[1].split(","),
+            [
+                "Beta Defender",
+                "29.7",
+                "0",
+                "29.7",
+                "52",
+                "Chelsea",
+                "Defender",
+                "29.7",
+                "5.0",
+                str(29.7 / fpl_module.forecastweeks),
+                "5.0",
+                "4.8",
+                "4.7",
+                "4.9",
+                "5.1",
+                "5.2",
+            ],
+        )
+
+    def test_inspection_output_uses_active_forecast_horizon(self):
+        players = fpl.load_fplreview_players(FIXTURE)
+
+        lines = format_playerkeydata_lines(
+            players,
+            2,
+            fpl_module.playertype,
+        )
+
+        self.assertEqual(lines[1].split(",")[-2:], ["5.0", "4.8"])
+        self.assertEqual(len(lines[1].split(",")), 12)
 
     def test_mapped_players_keep_existing_cost_and_availability_shape(self):
         players = fpl.load_fplreview_players(FIXTURE)

--- a/tests/test_ga_runner.py
+++ b/tests/test_ga_runner.py
@@ -161,16 +161,24 @@ class GARunnerTests(unittest.TestCase):
         self.assertEqual(first["generation_count"], second["generation_count"])
 
     def test_runner_horizon_missing_columns_fails_before_population_creation(self):
+        scenario_path = self.write_scenario("scenario-9.json", gameweek=9)
+
         with self.assertRaisesRegex(ValueError, "Missing required fplreview gameweek columns: 9_Pts"):
-            with redirect_stdout(io.StringIO()):
-                ga_module.run(
-                    input_path=FIXTURE,
-                    population_size=6,
-                    generation_limit=1,
-                    seed=7,
-                    gameweek=9,
-                    forecastweeks=1,
-                )
+            with patch.object(ga_module, "validate_scenario_file") as validate_scenario:
+                with patch.object(ga_module, "Population") as population:
+                    with redirect_stdout(io.StringIO()):
+                        ga_module.run(
+                            input_path=FIXTURE,
+                            scenario_path=scenario_path,
+                            population_size=6,
+                            generation_limit=1,
+                            seed=7,
+                            gameweek=9,
+                            forecastweeks=1,
+                        )
+
+        validate_scenario.assert_not_called()
+        population.assert_not_called()
 
     def test_runner_defaults_do_not_inherit_prior_horizon_overrides(self):
         with redirect_stdout(io.StringIO()):


### PR DESCRIPTION
## Summary

FPLgen's fplreview import path now has explicit boundaries for reading source CSVs, normalizing projection values, preparing scorer-compatible players, and formatting inspection output. The GA and scoring code still consume the same player shape, so this makes the data path easier to test and evolve without changing optimizer behavior.

## What changed

- Added a fplreview-specific projection boundary module for CSV source import, projection normalization, scorer preparation, and `playerkeydata` formatting.
- Kept the existing `fpl.py` helper surface as compatibility wrappers around the new boundary.
- Added requirements and implementation-plan docs for the boundary split.
- Strengthened regression coverage around projection values, unknown-team mapping, missing headers, forecast-horizon inspection output, and failure ordering before scenario validation or population creation.

## Validation

- `python3 -m py_compile code/*.py`
- `python3 -m unittest discover -s tests` -> 60 tests

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
